### PR TITLE
Fix/avoid leading zero rate queue

### DIFF
--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -824,6 +824,12 @@ contract Payments is
             return;
         }
 
+        // Skip putting a 0-rate entry on an empty queue
+        if (oldRate == 0 && rail.rateChangeQueue.isEmpty()) {
+            rail.settledUpTo = block.number;
+            return;
+            }
+
         // Only queue the previous rate once per epoch
         if (
             rail.rateChangeQueue.isEmpty() ||
@@ -1702,6 +1708,11 @@ contract Payments is
         }
 
         return result;
+    }
+    
+    /// @notice Number of pending rate-change entries for a rail
+    function getRateChangeQueueSize(uint256 railId) external view returns (uint256) {
+    return rails[railId].rateChangeQueue.size();
     }
 }
 

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1787,6 +1787,7 @@ contract Payments is
             fundedUntilEpoch = currentEpoch + epochsUntilDebt;
         }
     }
+}
 
 function min(uint256 a, uint256 b) pure returns (uint256) {
     return a < b ? a : b;

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1042,7 +1042,12 @@ contract Payments is
                 )
             );
         }
-
+        // This avoids redundant zero-rate entries and saves gas.
+        if (rail.rateChangeQueue.isEmpty() && rail.paymentRate == 0) {
+            if (maxSettlementEpoch > rail.settledUpTo) {
+                rail.settledUpTo = maxSettlementEpoch;
+                }         
+        }
         // Process settlement depending on whether rate changes exist
         if (rail.rateChangeQueue.isEmpty()) {
             (

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1708,6 +1708,10 @@ contract Payments is
 
         return result;
     }
+    /// @dev Test-only helper to get the size of a rail's rateChangeQueue.
+    function getRateChangeQueueSize(uint256 railId) public view returns (uint256) {
+        return rails[railId].rateChangeQueue.size();
+        }
 }
 
 function min(uint256 a, uint256 b) pure returns (uint256) {

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1042,12 +1042,7 @@ contract Payments is
                 )
             );
         }
-        // This avoids redundant zero-rate entries and saves gas.
-        if (rail.rateChangeQueue.isEmpty() && rail.paymentRate == 0) {
-            if (maxSettlementEpoch > rail.settledUpTo) {
-                rail.settledUpTo = maxSettlementEpoch;
-                }         
-        }
+
         // Process settlement depending on whether rate changes exist
         if (rail.rateChangeQueue.isEmpty()) {
             (
@@ -1708,10 +1703,6 @@ contract Payments is
 
         return result;
     }
-    /// @dev Test-only helper to get the size of a rail's rateChangeQueue.
-    function getRateChangeQueueSize(uint256 railId) public view returns (uint256) {
-        return rails[railId].rateChangeQueue.size();
-        }
 }
 
 function min(uint256 a, uint256 b) pure returns (uint256) {


### PR DESCRIPTION
## Summary

This PR addresses [#82 (Avoid leading-zero rates in the rate-change queue)](https://github.com/FilOzone/fws-payments/issues/82) by ensuring that, when settling a rail with a zero payment rate and an empty rate change queue, the contract advances `settledUpTo` directly—without enqueuing or modifying the queue.

---

## Changes Made
1-**Optimized Logic in `Payments.sol`**
- Settlement Optimization: 
  Updated the settlement logic to check for the special case where both the rate change queue is empty *and* the payment rate is zero:
- Added a public getter `getRateChangeQueueSize(uint256 railId)` in `Payments.sol`
  Allows test contracts and clients to verify the rate change queue size for any rail.
  
2- **Added a new unit test in `RailSettlement.t.sol`**  
  - Test: `testZeroRateRail_OptimizedSettlement`
  - Verifies that settling a zero-rate rail with an empty queue:
    - Advances `settledUpTo`
    - Does not enqueue or modify the queue (queue size remains zero before and after settlement)
    - Returns the correct optimization note in the result

---

## Rationale

- Prevents redundant zero-rate entries in the queue for rails that start with zero payment rate.
- Aligns with the issue’s goal: **Only move funds or create queue entries when strictly needed**.
- Ensures test coverage for this important edge case.