### PR TITLE
feat:commission recipient architecture enhancement

### DIFF
--- a/test/AccountLockupSettlement.t.sol
+++ b/test/AccountLockupSettlement.t.sol
@@ -68,7 +68,8 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             lockupRate, // payment rate
             lockupPeriod, // lockup period
             0, // no fixed lockup
-            address(0) // no fixed lockup
+            address(0), // no fixed lockup
+            SERVICE_FEE_RECIPIENT // operator comission fee receiver
         );
         assertEq(railId, 1);
 
@@ -112,7 +113,8 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             lockupRate, // Very high payment rate (20 ether per block)
             1, // lockup period
             0, // no fixed lockup
-            address(0) // no fixed lockup
+            address(0), // no fixed lockup
+            SERVICE_FEE_RECIPIENT
         );
 
         // When a rail is created, its settledUpTo is set to the current block
@@ -159,7 +161,8 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             lockupRate, // 1 token per block
             lockupPeriod, // Lockup period of 30 blocks
             initialLockup, // initial fixed lockup of 10 ether
-            address(0) // no fixed lockup
+            address(0), // no fixed lockup
+            SERVICE_FEE_RECIPIENT // operator comission fee receiver
         );
 
         // Roll forward many blocks
@@ -198,7 +201,8 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             0, // no payment rate
             10, // Lockup period
             DEPOSIT_AMOUNT, // fixed lockup equal to all funds
-            address(0) // no fixed lockup
+            address(0), // no fixed lockup
+            SERVICE_FEE_RECIPIENT // operator comission fee receiver
         );
 
         // Verify the account state
@@ -233,7 +237,8 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             USER1,
             USER2,
             address(0),
-            0
+            0,
+            SERVICE_FEE_RECIPIENT // operator comission fee receiver
         );
 
         // This should fail because lockupFixed > available funds
@@ -263,7 +268,8 @@ contract AccountLockupSettlementTest is Test, BaseTestHelper {
             lockupRate, // 1 ether per block
             lockupPeriod, // Lockup period of 10 blocks
             initialLockup, // 50 ether fixed lockup
-            address(0) // no fixed lockup
+            address(0), // no fixed lockup
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Total lockup at rail creation: 50 ether fixed + (1 ether * 10 blocks) = 60 ether

--- a/test/AccountManagement.t.sol
+++ b/test/AccountManagement.t.sol
@@ -174,7 +174,9 @@ contract AccountManagementTest is Test, BaseTestHelper {
             0, // no payment rate
             0, // no lockup period
             lockedAmount, // fixed lockup of half the deposit
-            address(0) // no fixed lockup
+            address(0), // no fixed lockup
+            SERVICE_FEE_RECIPIENT // operator commision receiver
+
         );
 
         // Verify lockup worked by checking account state
@@ -221,7 +223,9 @@ contract AccountManagementTest is Test, BaseTestHelper {
             lockupRate, // payment rate (creates lockup rate)
             10, // lockup period
             0, // no fixed lockup
-            address(0) // no fixed lockup
+            address(0), // no fixed lockup
+            SERVICE_FEE_RECIPIENT // operator commision receiver
+
         );
 
         // Create a second rail to get to 1 ether lockup rate on the account
@@ -232,7 +236,9 @@ contract AccountManagementTest is Test, BaseTestHelper {
             lockupRate, // payment rate (creates another 0.5 ether/block lockup rate)
             10, // lockup period
             0, // no fixed lockup
-            address(0) // no fixed lockup
+            address(0), // no fixed lockup
+            SERVICE_FEE_RECIPIENT // operator commision receiver
+
         );
 
         // Advance 10 blocks to create settlement gap

--- a/test/Fees.t.sol
+++ b/test/Fees.t.sol
@@ -117,7 +117,9 @@ contract FeesTest is Test, BaseTestHelper {
             RAIL1_RATE,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0), // No arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
+
         );
 
         // Create a rail with token2
@@ -127,7 +129,9 @@ contract FeesTest is Test, BaseTestHelper {
             USER1, // from
             USER2, // to
             address(0), // no arbiter
-            0 // no commission
+            0, // no commission
+            SERVICE_FEE_RECIPIENT // operator commision receiver
+
         );
 
         // Set rail2 parameters
@@ -140,7 +144,8 @@ contract FeesTest is Test, BaseTestHelper {
             USER1, // from
             USER2, // to
             address(0), // no arbiter
-            0 // no commission
+            0, // no commission
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Set rail3 parameters

--- a/test/OperatorApproval.t.sol
+++ b/test/OperatorApproval.t.sol
@@ -119,7 +119,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         );
 
         // Create a rail
-        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         // Verify no allowance consumed yet
         helper.verifyOperatorAllowances(
@@ -188,7 +188,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         );
 
         // 4. Create second rail and set rate
-        uint256 railId2 = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId2 = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         uint256 rate2 = 15 ether;
         vm.startPrank(OPERATOR);
@@ -220,7 +220,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         );
 
         // Create rail
-        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         // Set rate to exactly the limit
         vm.startPrank(OPERATOR);
@@ -247,7 +247,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         );
 
         // Create rail
-        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         // Set payment rate
         uint256 paymentRate = 10 ether;
@@ -336,7 +336,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         );
 
         // Create rail
-        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         // Set payment rate
         uint256 paymentRate = 10 ether;
@@ -365,7 +365,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         );
 
         // Create rail
-        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         // Use exactly the available rate allowance
         vm.startPrank(OPERATOR);
@@ -393,7 +393,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         helper.setupOperatorApproval(USER1, OPERATOR, 0, 0,MAX_LOCKUP_PERIOD);
 
         // Create rail with zero allowances
-        uint256 railId2 = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId2 = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         // Attempt to set non-zero rate (should fail)
         vm.startPrank(OPERATOR);
@@ -418,7 +418,8 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
                 USER1,
                 USER2,
                 address(0),
-                0
+                0,
+                SERVICE_FEE_RECIPIENT // operator commision receiver
             )
         returns (uint256) {
             // If we get here, the function did not revert
@@ -447,7 +448,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
             MAX_LOCKUP_PERIOD
         );
 
-        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         // 3. Test non-operator rail modification
         vm.startPrank(USER1);
@@ -475,7 +476,8 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
                 USER1,
                 USER2,
                 address(0),
-                0
+                0,
+                SERVICE_FEE_RECIPIENT // operator commision receiver
             )
         returns (uint256) {
             // If we get here, the function did not revert
@@ -535,7 +537,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         );
 
         // Create rail with fixed lockup
-        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         uint256 paymentRate = 10 ether;
         uint256 fixedLockup = 100 ether;
@@ -578,7 +580,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         );
 
         // Create rail
-        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0), SERVICE_FEE_RECIPIENT);
 
         uint256 paymentRate = 10 ether;
         uint256 fixedLockup = 800 ether;
@@ -646,7 +648,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         helper.setupOperatorApproval(USER1, OPERATOR, 90 ether, 30 ether,MAX_LOCKUP_PERIOD);
 
         // Operator creates a rail using 50 rate/20 lockup
-        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         vm.startPrank(OPERATOR);
         payments.modifyRailPayment(railId, 50 ether, 0);
@@ -691,7 +693,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         // they should not be able to create new rail configurations with non-zero rate/lockup
 
         // Create a new rail, which should succeed
-        uint256 railId2 = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId2 = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         // But attempting to set non-zero rate on the new rail should fail due to insufficient allowance
         vm.startPrank(OPERATOR);
@@ -718,7 +720,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         );
 
         // Create rail and set rate
-        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         vm.startPrank(OPERATOR);
         payments.modifyRailPayment(railId, 50 ether, 0);
@@ -772,7 +774,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
 
         // 3. Test reducing lockup allowance below current usage
         // Create a new rail for lockup testing
-        uint256 railId2 = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId2 = helper.createRail(USER1, USER2, OPERATOR, address(0), SERVICE_FEE_RECIPIENT);
 
         // Reset approval with high lockup
         helper.setupOperatorApproval(USER1, OPERATOR, 50 ether, 1000 ether,MAX_LOCKUP_PERIOD);
@@ -820,9 +822,9 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         );
 
         // Create two rails with different parameters
-        uint256 railId1 = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId1 = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
-        uint256 railId2 = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId2 = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         // Set parameters for first rail
         uint256 rate1 = 10 ether;
@@ -900,7 +902,8 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
                 USER1,
                 USER2,
                 address(0),
-                0
+                0,
+                SERVICE_FEE_RECIPIENT // operator commision receiver
             )
         returns (uint256) {
             // If we get here, the function did not revert
@@ -933,7 +936,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         vm.stopPrank();
 
         // Operator should be able to create a new rail
-        uint256 railId3 = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId3 = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         // But should not be able to exceed the new allowance
         vm.startPrank(OPERATOR);
@@ -954,7 +957,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
         );
 
         // Create rail
-        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
 
         // Set payment rate
         uint256 paymentRate = 10 ether;
@@ -986,7 +989,7 @@ contract OperatorApprovalTest is Test, BaseTestHelper {
             initialMaxLockupPeriod
         );
         // Create rail
-        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        uint256 railId = helper.createRail(USER1, USER2, OPERATOR, address(0),SERVICE_FEE_RECIPIENT);
         // Set payment rate and high lockup period
         uint256 paymentRate = 10 ether;
         vm.startPrank(OPERATOR);

--- a/test/PaymentsAccessControl.t.sol
+++ b/test/PaymentsAccessControl.t.sol
@@ -33,7 +33,7 @@ contract AccessControlTest is Test, BaseTestHelper {
         helper.makeDeposit(USER1, USER1, DEPOSIT_AMOUNT);
 
         // Create a rail for testing
-        railId = helper.createRail(USER1, USER2, OPERATOR, address(0));
+        railId = helper.createRail(USER1, USER2, OPERATOR, address(0), SERVICE_FEE_RECIPIENT);
 
         // Set up rail parameters
         vm.startPrank(OPERATOR);

--- a/test/RailGetters.t.sol
+++ b/test/RailGetters.t.sol
@@ -90,7 +90,8 @@ contract PayeeRailsTest is Test, BaseTestHelper {
             5 ether, // rate
             10, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0), // No arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Rail 2: Another rail with token1 and USER2 as payee
@@ -101,7 +102,8 @@ contract PayeeRailsTest is Test, BaseTestHelper {
             3 ether, // rate
             10, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0), // No arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Rail 3: Will be terminated
@@ -112,7 +114,8 @@ contract PayeeRailsTest is Test, BaseTestHelper {
             2 ether, // rate
             5, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0), // No arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Rail 4: With token2 and USER2 as payee
@@ -122,7 +125,8 @@ contract PayeeRailsTest is Test, BaseTestHelper {
             USER1, // from
             USER2, // to (payee)
             address(0), // no arbiter
-            0 // no commission
+            0, // no commission
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
         payments.modifyRailPayment(rail4Id, 4 ether, 0);
         payments.modifyRailLockup(rail4Id, 10, 0);
@@ -136,7 +140,8 @@ contract PayeeRailsTest is Test, BaseTestHelper {
             1 ether, // rate
             10, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0), // No arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Terminate Rail 3

--- a/test/RailSettlement.t.sol
+++ b/test/RailSettlement.t.sol
@@ -49,7 +49,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0), // No arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Advance a few blocks
@@ -76,7 +77,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             3, // lockupPeriod - total locked: 150 ether (3 * 50)
             0, // No fixed lockup
-            address(0)
+            address(0),
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Advance 7 blocks
@@ -128,7 +130,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(0) // Standard arbiter
+            address(0), // Standard arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
         uint256 newRate1 = 6 ether;
         uint256 newRate2 = 7 ether;
@@ -195,7 +198,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(arbiter) // Standard arbiter
+            address(arbiter), // Standard arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Advance several blocks
@@ -244,7 +248,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(arbiter) // Standard arbiter
+            address(arbiter), // Standard arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         vm.startPrank(OPERATOR);
@@ -289,7 +294,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(arbiter) // Reduced amount arbiter
+            address(arbiter), // Reduced amount arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Advance several blocks
@@ -354,7 +360,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(arbiter) // Reduced duration arbiter
+            address(arbiter), // Reduced duration arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Advance several blocks
@@ -400,7 +407,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(arbiter) // Malicious arbiter
+            address(arbiter), // Malicious arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Advance several blocks
@@ -443,7 +451,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             lockupPeriod, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0), // No arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Advance several blocks
@@ -540,7 +549,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0), // No arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Settle immediately without advancing blocks - should be a no-op
@@ -579,7 +589,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             lockupPeriod, 
             0, // No fixed lockup
-            address(arbiter)
+            address(arbiter),
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Simulate 5 blocks passing (blocks 1-5)
@@ -594,8 +605,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
             ,
             ,
         ) = helper.getOperatorAllowanceAndUsage(USER1, OPERATOR);
-        helper.setupOperatorApproval(USER1, OPERATOR, rateAllowance  * 2, lockupAllowance + 10 * rate,
-        MAX_LOCKUP_PERIOD);
+        helper.setupOperatorApproval(USER1, OPERATOR, rateAllowance  * 2, lockupAllowance + 10 * rate,MAX_LOCKUP_PERIOD);
 
         // Operator doubles the payment rate from 5 ETH to 10 ETH per block
         // This creates a rate change in the queue
@@ -639,7 +649,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             lockupPeriod,
             0, // No fixed lockup
-            address(arbiter)
+            address(arbiter),
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
         // Simulate 5 blocks passing (blocks 1-5)
@@ -663,8 +674,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
             ,
             ,
         ) = helper.getOperatorAllowanceAndUsage(USER1, OPERATOR);
-        helper.setupOperatorApproval(USER1, OPERATOR, rateAllowance  * 2, lockupAllowance + 10 * rate,
-        MAX_LOCKUP_PERIOD);
+        helper.setupOperatorApproval(USER1, OPERATOR, rateAllowance  * 2, lockupAllowance + 10 * rate,MAX_LOCKUP_PERIOD);
 
         // Operator doubles the payment rate from 5 ETH to 10 ETH per block
         // This creates a rate change in the queue
@@ -726,7 +736,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
             USER1,
             USER2,
             address(0), // no arbiter
-            operatorCommissionBps
+            operatorCommissionBps,
+            SERVICE_FEE_RECIPIENT // operator commision receiver
         );
         vm.stopPrank();
 
@@ -749,6 +760,10 @@ contract RailSettlementTest is Test, BaseTestHelper {
             OPERATOR
         );
         uint256 feesBefore = payments.accumulatedFees(address(token));
+
+        uint256 operatorBalanceBefore = token.balanceOf(
+            SERVICE_FEE_RECIPIENT
+        );
 
         // --- Settle Rail ---
         vm.startPrank(USER1); // Any participant can settle
@@ -816,13 +831,18 @@ contract RailSettlementTest is Test, BaseTestHelper {
         );
         assertEq(
             operatorAfter.funds,
-            operatorBefore.funds + expectedOperatorCommission,
+            operatorBefore.funds,
             "Operator funds mismatch"
         );
         assertEq(
             feesAfter,
             feesBefore + expectedPaymentFee,
             "Accumulated fees mismatch"
+        );
+        assertEq(
+            token.balanceOf(SERVICE_FEE_RECIPIENT),
+            operatorBalanceBefore + expectedOperatorCommission,
+            "Operator commission balance mismatch"
         );
 
         // --- Test Fees Withdrawal and Subsequent Fee Accumulation ---

--- a/test/helpers/BaseTestHelper.sol
+++ b/test/helpers/BaseTestHelper.sol
@@ -8,4 +8,5 @@ contract BaseTestHelper {
     address public constant OPERATOR = address(0x4);
     address public constant OPERATOR2 = address(0x5);
     address public constant ARBITER = address(0x6);
+    address public constant SERVICE_FEE_RECIPIENT = address(0x7);
 }

--- a/test/helpers/PaymentsTestHelpers.sol
+++ b/test/helpers/PaymentsTestHelpers.sol
@@ -313,7 +313,8 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         address from,
         address to,
         address railOperator,
-        address arbiter
+        address arbiter,
+        address serviceFeeRecipient
     ) public returns (uint256) {
         vm.startPrank(railOperator);
         uint256 railId = payments.createRail(
@@ -321,7 +322,8 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
             from,
             to,
             arbiter,
-            0 // commissionRateBps
+            0, // commissionRateBps
+            serviceFeeRecipient // serviceFeeRecipient
         );
         vm.stopPrank();
 
@@ -332,6 +334,11 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         assertEq(rail.to, to, "Rail recipient address mismatch");
         assertEq(rail.arbiter, arbiter, "Rail arbiter address mismatch");
         assertEq(rail.operator, railOperator, "Rail operator address mismatch");
+        assertEq(
+            rail.serviceFeeRecipient,
+            serviceFeeRecipient,
+            "Rail service fee recipient address mismatch"
+        );
 
         return railId;
     }
@@ -343,7 +350,8 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         uint256 paymentRate,
         uint256 lockupPeriod,
         uint256 lockupFixed,
-        address arbiter
+        address arbiter,
+        address serviceFeeRecipient
     ) public returns (uint256 railId) {
         // Calculate required allowances for the rail
         uint256 requiredRateAllowance = paymentRate;
@@ -381,7 +389,7 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
             vm.stopPrank();
         }
 
-        railId = createRail(from, to, railOperator, arbiter);
+        railId = createRail(from, to, railOperator, arbiter, serviceFeeRecipient);
 
         // Get operator usage before modifications
         (, , , uint256 rateUsageBefore, uint256 lockupUsageBefore,) = payments

--- a/test/helpers/RailSettlementHelpers.sol
+++ b/test/helpers/RailSettlementHelpers.sol
@@ -40,7 +40,8 @@ contract RailSettlementHelpers is Test {
         uint256[] memory rates,
         uint256 lockupPeriod,
         uint256 lockupFixed,
-        uint256 maxLokkupPeriod
+        uint256 maxLokkupPeriod,
+        address serviceFeeRecipient
     ) public returns (uint256) {
         require(
             arbiter != address(0),
@@ -75,7 +76,8 @@ contract RailSettlementHelpers is Test {
             rates[0], // Initial rate
             lockupPeriod,
             lockupFixed,
-            arbiter
+            arbiter,
+            serviceFeeRecipient
         );
 
         // Apply rate changes for the rest of the rates
@@ -99,7 +101,8 @@ contract RailSettlementHelpers is Test {
         uint256 paymentRate,
         uint256 lockupPeriod,
         uint256 fundAmount,
-        uint256 fixedLockup
+        uint256 fixedLockup,
+        address serviceFeeRecipient
     ) public returns (uint256) {
         baseHelper.makeDeposit(from, from, fundAmount);
 
@@ -111,7 +114,8 @@ contract RailSettlementHelpers is Test {
             paymentRate,
             lockupPeriod,
             fixedLockup,
-            address(0)
+            address(0),
+            serviceFeeRecipient
         );
 
         // Advance blocks past the lockup period to force the rail into debt


### PR DESCRIPTION
Fixes : #114 

### Description 

This pr adds all the enhancements mentioned in : #114 

### Changes - 

- Added commissionRecipient parameter to createRail() function
- If serviceFeeRecipient  is provided, commissions go there during the settlement
- If serviceFeeRecipient  is address(0), operator recieves the commission