### PR TITLE
Migrate ReentrancyGuard with upgradeable version in Payments contract

### DIFF
--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
@@ -37,7 +37,7 @@ contract Payments is
     Initializable,
     UUPSUpgradeable,
     OwnableUpgradeable,
-    ReentrancyGuard
+    ReentrancyGuardUpgradeable
 {
     using SafeERC20 for IERC20;
     using RateChangeQueue for RateChangeQueue.Queue;
@@ -152,6 +152,7 @@ contract Payments is
     function initialize() public initializer {
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
+        __ReentrancyGuard_init();
         _nextRailId = 1;
     }
 


### PR DESCRIPTION
## Summary

This PR updates the Payments contract to use `ReentrancyGuardUpgradeable` instead of the regular `ReentrancyGuard`, which is necessary for compatibility with the proxy-based upgradeable pattern.

Other OpenZeppelin imports (`SafeERC20`, `IERC20`, `IERC20Permit`, and `Strings`) remain unchanged as they are stateless/interfaces and safe to use in upgradeable contracts.