### PR TITLE
refactor: replace hardcoded ERC1967Proxy import with remapped path

### DIFF
--- a/src/ERC1967Proxy.sol
+++ b/src/ERC1967Proxy.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.20;
 
-import {ERC1967Proxy} from "../lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract PaymentsERC1967Proxy is ERC1967Proxy {
     constructor(


### PR DESCRIPTION
Updated ERC1967Proxy import to use @openzeppelin remapping instead of a hardcoded path.

This aligns with the existing usage in the Payments contract, where remapped imports are already used.
