### PR TITLE
Change Arbitration to Validation

### DIFF
--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -11,25 +11,25 @@ import "./RateChangeQueue.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 
-interface IArbiter {
-    struct ArbitrationResult {
-        // The actual payment amount determined by the arbiter after arbitration of a rail during settlement
+interface IValidator {
+    struct ValidationResult {
+        // The actual payment amount determined by the validator after validation of a rail during settlement
         uint256 modifiedAmount;
         // The epoch up to and including which settlement should occur.
         uint256 settleUpto;
-        // A placeholder note for any additional information the arbiter wants to send to the caller of `settleRail`
+        // A placeholder note for any additional information the validator wants to send to the caller of `settleRail`
         string note;
     }
 
-    function arbitratePayment(
+    function validatePayment(
         uint256 railId,
         uint256 proposedAmount,
         // the epoch up to and including which the rail has already been settled
         uint256 fromEpoch,
-        // the epoch up to and including which arbitration is requested; payment will be arbitrated for (toEpoch - fromEpoch) epochs
+        // the epoch up to and including which validation is requested; payment will be validated for (toEpoch - fromEpoch) epochs
         uint256 toEpoch,
         uint256 rate
-    ) external returns (ArbitrationResult memory result);
+    ) external returns (ValidationResult memory result);
 }
 
 // @title Payments contract.
@@ -60,7 +60,7 @@ contract Payments is
         address from;
         address to;
         address operator;
-        address arbiter;
+        address validator;
         uint256 paymentRate;
         uint256 lockupPeriod;
         uint256 lockupFixed;
@@ -96,7 +96,7 @@ contract Payments is
         address from;
         address to;
         address operator;
-        address arbiter;
+        address validator;
         uint256 paymentRate;
         uint256 lockupPeriod;
         uint256 lockupFixed;
@@ -300,7 +300,7 @@ contract Payments is
                 from: rail.from,
                 to: rail.to,
                 operator: rail.operator,
-                arbiter: rail.arbiter,
+                validator: rail.validator,
                 paymentRate: rail.paymentRate,
                 lockupPeriod: rail.lockupPeriod,
                 lockupFixed: rail.lockupFixed,
@@ -508,7 +508,7 @@ contract Payments is
     /// @param token The ERC20 token address for payments on this rail.
     /// @param from The client address (payer) for this rail.
     /// @param to The recipient address for payments on this rail.
-    /// @param arbiter Optional address of an arbiter contract (can be address(0) for no arbitration).
+    /// @param validator Optional address of an validator contract (can be address(0) for no validation).
     /// @param commissionRateBps Optional operator commission in basis points (0-10000).
     /// @return The ID of the newly created rail.
     /// @custom:constraint Caller must be approved as an operator by the client (from address).
@@ -516,7 +516,7 @@ contract Payments is
         address token,
         address from,
         address to,
-        address arbiter,
+        address validator,
         uint256 commissionRateBps
     )
         external
@@ -546,7 +546,7 @@ contract Payments is
         rail.from = from;
         rail.to = to;
         rail.operator = operator;
-        rail.arbiter = arbiter;
+        rail.validator = validator;
         rail.settledUpTo = block.number;
         rail.endEpoch = 0;
         rail.commissionRateBps = commissionRateBps;
@@ -830,7 +830,7 @@ contract Payments is
             rail.rateChangeQueue.isEmpty() ||
             rail.rateChangeQueue.peekTail().untilEpoch != block.number
         ) {
-            // For arbitrated rails, we need to enqueue the old rate.
+            // For validated rails, we need to enqueue the old rate.
             // This ensures that the old rate is applied up to and including the current block.
             // The new rate will be applicable starting from the next block.
             rail.rateChangeQueue.enqueue(oldRate, block.number);
@@ -916,7 +916,7 @@ contract Payments is
         }
     }
 
-    /// @notice Settles payments for a terminated rail without arbitration. This may only be called by the payee and after the terminated rail's max settlement epoch has passed. It's an escape-hatch to unblock payments in an otherwise stuck rail (e.g., due to a buggy arbiter contract) and it always pays in full.
+    /// @notice Settles payments for a terminated rail without validation. This may only be called by the payee and after the terminated rail's max settlement epoch has passed. It's an escape-hatch to unblock payments in an otherwise stuck rail (e.g., due to a buggy validator contract) and it always pays in full.
     /// @param railId The ID of the rail to settle.
     /// @return totalSettledAmount The total amount settled and transferred.
     /// @return totalNetPayeeAmount The net amount credited to the payee after fees.
@@ -924,7 +924,7 @@ contract Payments is
     /// @return totalOperatorCommission The commission credited to the operator.
     /// @return finalSettledEpoch The epoch up to which settlement was actually completed.
     /// @return note Additional information about the settlement.
-    function settleTerminatedRailWithoutArbitration(
+    function settleTerminatedRailWithoutValidation(
         uint256 railId
     )
         external
@@ -948,13 +948,13 @@ contract Payments is
         );
         require(
             block.number > maxSettleEpoch,
-            "terminated rail can only be settled without arbitration after max settlement epoch"
+            "terminated rail can only be settled without validation after max settlement epoch"
         );
 
         return settleRailInternal(railId, maxSettleEpoch, true);
     }
 
-    /// @notice Settles payments for a rail up to the specified epoch. Settlement may fail to reach the target epoch if either the client lacks the funds to pay up to the current epoch or the arbiter refuses to settle the entire requested range.
+    /// @notice Settles payments for a rail up to the specified epoch. Settlement may fail to reach the target epoch if either the client lacks the funds to pay up to the current epoch or the validator refuses to settle the entire requested range.
     /// @param railId The ID of the rail to settle.
     /// @param untilEpoch The epoch up to which to settle (must not exceed current block number).
     /// @return totalSettledAmount The total amount settled and transferred.
@@ -962,7 +962,7 @@ contract Payments is
     /// @return totalPaymentFee The fee retained by the payment contract.
     /// @return totalOperatorCommission The commission credited to the operator.
     /// @return finalSettledEpoch The epoch up to which settlement was actually completed.
-    /// @return note Additional information about the settlement (especially from arbitration).
+    /// @return note Additional information about the settlement (especially from validation).
     function settleRail(
         uint256 railId,
         uint256 untilEpoch
@@ -987,7 +987,7 @@ contract Payments is
     function settleRailInternal(
         uint256 railId,
         uint256 untilEpoch,
-        bool skipArbitration
+        bool skipValidation
     )
         internal
         returns (
@@ -1057,7 +1057,7 @@ contract Payments is
                     startEpoch,
                     maxSettlementEpoch,
                     rail.paymentRate,
-                    skipArbitration
+                    skipValidation
                 );
 
             require(rail.settledUpTo > startEpoch, "No progress in settlement");
@@ -1089,7 +1089,7 @@ contract Payments is
                     rail.paymentRate,
                     startEpoch,
                     maxSettlementEpoch,
-                    skipArbitration
+                    skipValidation
                 );
 
             return
@@ -1177,7 +1177,7 @@ contract Payments is
         uint256 currentRate,
         uint256 startEpoch,
         uint256 targetEpoch,
-        bool skipArbitration
+        bool skipValidation
     )
         internal
         returns (
@@ -1224,29 +1224,29 @@ contract Payments is
                 );
             }
 
-            // Settle the current segment with potentially arbitrated outcomes
+            // Settle the current segment with potentially validated outcomes
             (
                 uint256 segmentSettledAmount,
                 uint256 segmentNetPayeeAmount,
                 uint256 segmentPaymentFee,
                 uint256 segmentOperatorCommission,
-                string memory arbitrationNote
+                string memory validationNote
             ) = _settleSegment(
                     railId,
                     state.processedEpoch,
                     segmentEndBoundary,
                     segmentRate,
-                    skipArbitration
+                    skipValidation
                 );
 
-            // If arbiter returned no progress, exit early without updating state
+            // If validator returned no progress, exit early without updating state
             if (rail.settledUpTo <= state.processedEpoch) {
                 return (
                     state.totalSettledAmount,
                     state.totalNetPayeeAmount,
                     state.totalPaymentFee,
                     state.totalOperatorCommission,
-                    arbitrationNote
+                    validationNote
                 );
             }
 
@@ -1256,20 +1256,20 @@ contract Payments is
             state.totalPaymentFee += segmentPaymentFee;
             state.totalOperatorCommission += segmentOperatorCommission;
 
-            // If arbiter partially settled the segment, exit early
+            // If validator partially settled the segment, exit early
             if (rail.settledUpTo < segmentEndBoundary) {
                 return (
                     state.totalSettledAmount,
                     state.totalNetPayeeAmount,
                     state.totalPaymentFee,
                     state.totalOperatorCommission,
-                    arbitrationNote
+                    validationNote
                 );
             }
 
             // Successfully settled full segment, update tracking values
             state.processedEpoch = rail.settledUpTo;
-            state.note = arbitrationNote;
+            state.note = validationNote;
 
             // Remove the processed rate change from the queue
             if (!rateQueue.isEmpty()) {
@@ -1318,7 +1318,7 @@ contract Payments is
         uint256 epochStart,
         uint256 epochEnd,
         uint256 rate,
-        bool skipArbitration
+        bool skipValidation
     )
         internal
         returns (
@@ -1338,16 +1338,16 @@ contract Payments is
             return (0, 0, 0, 0, "Zero rate payment rail");
         }
 
-        // Calculate the default settlement values (without arbitration)
+        // Calculate the default settlement values (without validation)
         uint256 duration = epochEnd - epochStart;
         uint256 settledAmount = rate * duration;
         uint256 settledUntilEpoch = epochEnd;
         note = "";
 
-        // If this rail has an arbiter and we're not skipping arbitration, let it decide on the final settlement amount
-        if (rail.arbiter != address(0) && !skipArbitration) {
-            IArbiter arbiter = IArbiter(rail.arbiter);
-            IArbiter.ArbitrationResult memory result = arbiter.arbitratePayment(
+        // If this rail has an validator and we're not skipping validation, let it decide on the final settlement amount
+        if (rail.validator != address(0) && !skipValidation) {
+            IValidator validator = IValidator(rail.validator);
+            IValidator.ValidationResult memory result = validator.validatePayment(
                 railId,
                 settledAmount,
                 epochStart,
@@ -1355,26 +1355,26 @@ contract Payments is
                 rate
             );
 
-            // Ensure arbiter doesn't settle beyond our segment's end boundary
+            // Ensure validator doesn't settle beyond our segment's end boundary
             require(
                 result.settleUpto <= epochEnd,
-                "arbiter settled beyond segment end"
+                "validator settled beyond segment end"
             );
             require(
                 result.settleUpto >= epochStart,
-                "arbiter settled before segment start"
+                "validator settled before segment start"
             );
 
             settledUntilEpoch = result.settleUpto;
             settledAmount = result.modifiedAmount;
             note = result.note;
 
-            // Ensure arbiter doesn't allow more payment than the maximum possible
+            // Ensure validator doesn't allow more payment than the maximum possible
             // for the epochs they're confirming
             uint256 maxAllowedAmount = rate * (settledUntilEpoch - epochStart);
             require(
                 result.modifiedAmount <= maxAllowedAmount,
-                "arbiter modified amount exceeds maximum for settled duration"
+                "validator modified amount exceeds maximum for settled duration"
             );
         }
 
@@ -1520,7 +1520,7 @@ contract Payments is
         rail.from = address(0); // This now marks the rail as inactive
         rail.to = address(0);
         rail.operator = address(0);
-        rail.arbiter = address(0);
+        rail.validator = address(0);
         rail.paymentRate = 0;
         rail.lockupFixed = 0;
         rail.lockupPeriod = 0;

--- a/test/Fees.t.sol
+++ b/test/Fees.t.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
-import {Payments, IArbiter} from "../src/Payments.sol";
+import {Payments} from "../src/Payments.sol";
 import {MockERC20} from "./mocks/MockERC20.sol";
 import {PaymentsTestHelpers} from "./helpers/PaymentsTestHelpers.sol";
 import {RailSettlementHelpers} from "./helpers/RailSettlementHelpers.sol";
@@ -117,7 +117,7 @@ contract FeesTest is Test, BaseTestHelper {
             RAIL1_RATE,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0) // No validator
         );
 
         // Create a rail with token2
@@ -126,7 +126,7 @@ contract FeesTest is Test, BaseTestHelper {
             address(token2),
             USER1, // from
             USER2, // to
-            address(0), // no arbiter
+            address(0), // no validator
             0 // no commission
         );
 
@@ -139,7 +139,7 @@ contract FeesTest is Test, BaseTestHelper {
             address(token3),
             USER1, // from
             USER2, // to
-            address(0), // no arbiter
+            address(0), // no validator
             0 // no commission
         );
 

--- a/test/PaymentsAccessControl.t.sol
+++ b/test/PaymentsAccessControl.t.sol
@@ -126,7 +126,7 @@ contract AccessControlTest is Test, BaseTestHelper {
         vm.stopPrank();
     }
 
-    function testSettleTerminatedRailWithoutArbitration_RevertsWhenCalledByOperator()
+    function testSettleTerminatedRailWithoutValidation_RevertsWhenCalledByOperator()
         public
     {
         // 2. Add more funds
@@ -144,7 +144,7 @@ contract AccessControlTest is Test, BaseTestHelper {
         // Attempt to settle from operator account
         vm.startPrank(OPERATOR);
         vm.expectRevert("only the rail client can perform this action");
-        payments.settleTerminatedRailWithoutArbitration(railId);
+        payments.settleTerminatedRailWithoutValidation(railId);
         vm.stopPrank();
     }
 

--- a/test/RailGetters.t.sol
+++ b/test/RailGetters.t.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
-import {Payments, IArbiter} from "../src/Payments.sol";
+import {Payments} from "../src/Payments.sol";
 import {MockERC20} from "./mocks/MockERC20.sol";
 import {PaymentsTestHelpers} from "./helpers/PaymentsTestHelpers.sol";
 import {RailSettlementHelpers} from "./helpers/RailSettlementHelpers.sol";
@@ -90,7 +90,7 @@ contract PayeeRailsTest is Test, BaseTestHelper {
             5 ether, // rate
             10, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0) // No validator
         );
 
         // Rail 2: Another rail with token1 and USER2 as payee
@@ -101,7 +101,7 @@ contract PayeeRailsTest is Test, BaseTestHelper {
             3 ether, // rate
             10, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0) // No validator
         );
 
         // Rail 3: Will be terminated
@@ -112,7 +112,7 @@ contract PayeeRailsTest is Test, BaseTestHelper {
             2 ether, // rate
             5, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0) // No validator
         );
 
         // Rail 4: With token2 and USER2 as payee
@@ -121,7 +121,7 @@ contract PayeeRailsTest is Test, BaseTestHelper {
             address(token2),
             USER1, // from
             USER2, // to (payee)
-            address(0), // no arbiter
+            address(0), // no validator
             0 // no commission
         );
         payments.modifyRailPayment(rail4Id, 4 ether, 0);
@@ -136,7 +136,7 @@ contract PayeeRailsTest is Test, BaseTestHelper {
             1 ether, // rate
             10, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0) // No validator
         );
 
         // Terminate Rail 3

--- a/test/RailSettlement.t.sol
+++ b/test/RailSettlement.t.sol
@@ -3,9 +3,9 @@
 pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
-import {Payments, IArbiter} from "../src/Payments.sol";
+import {Payments} from "../src/Payments.sol";
 import {MockERC20} from "./mocks/MockERC20.sol";
-import {MockArbiter} from "./mocks/MockArbiter.sol";
+import {MockValidator} from "./mocks/MockValidator.sol";
 import {PaymentsTestHelpers} from "./helpers/PaymentsTestHelpers.sol";
 import {RailSettlementHelpers} from "./helpers/RailSettlementHelpers.sol";
 import {console} from "forge-std/console.sol";
@@ -49,7 +49,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0) // No validator
         );
 
         // Advance a few blocks
@@ -128,7 +128,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(0) // Standard arbiter
+            address(0) // Standard validator
         );
         uint256 newRate1 = 6 ether;
         uint256 newRate2 = 7 ether;
@@ -179,14 +179,14 @@ contract RailSettlementTest is Test, BaseTestHelper {
     }
 
     //--------------------------------
-    // 2. Arbitration Scenarios
+    // 2. Validation Scenarios
     //--------------------------------
 
-    function testArbitrationWithStandardApproval() public {
-        // Deploy a standard arbiter that approves everything
-        MockArbiter arbiter = new MockArbiter(MockArbiter.ArbiterMode.STANDARD);
+    function testValidationWithStandardApproval() public {
+        // Deploy a standard validator that approves everything
+        MockValidator validator = new MockValidator(MockValidator.ValidatorMode.STANDARD);
 
-        // Create a rail with the arbiter
+        // Create a rail with the validator
         uint256 rate = 5 ether;
         uint256 railId = helper.setupRailWithParameters(
             USER1,
@@ -195,16 +195,16 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(arbiter) // Standard arbiter
+            address(validator) // Standard validator
         );
 
         // Advance several blocks
         helper.advanceBlocks(5);
 
-        // Verify standard arbiter approves full amount
+        // Verify standard validator approves full amount
         uint256 expectedAmount = rate * 5; // 5 blocks * 5 ether
 
-        // Settle with arbitration
+        // Settle with validation
         RailSettlementHelpers.SettlementResult memory result = settlementHelper
             .settleRailAndVerify(
                 railId,
@@ -213,17 +213,17 @@ contract RailSettlementTest is Test, BaseTestHelper {
                 block.number
             );
 
-        // Verify arbiter note
+        // Verify validaton note
         assertEq(
             result.note,
             "Standard approved payment",
-            "Arbiter note should match"
+            "Validator note should match"
         );
     }
 
-    function testArbitrationWithMultipleRateChanges() public {
-        // Deploy a standard arbiter that approves everything
-        MockArbiter arbiter = new MockArbiter(MockArbiter.ArbiterMode.STANDARD);
+    function testValidationWithMultipleRateChanges() public {
+        // Deploy a standard validator that approves everything
+        MockValidator validator = new MockValidator(MockValidator.ValidatorMode.STANDARD);
 
         // Setup operator approval first
         helper.setupOperatorApproval(
@@ -234,7 +234,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
             MAX_LOCKUP_PERIOD // lockup period
         );
 
-        // Create a rail with the arbiter
+        // Create a rail with the validator
         uint256 rate = 1;
         uint256 expectedAmount = 0;
         uint256 railId = helper.setupRailWithParameters(
@@ -244,7 +244,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(arbiter) // Standard arbiter
+            address(validator) // Standard validator
         );
 
         vm.startPrank(OPERATOR);
@@ -256,7 +256,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
         }
         vm.stopPrank();
 
-        // Settle with arbitration
+        // Settle with validation
         RailSettlementHelpers.SettlementResult memory result = settlementHelper
             .settleRailAndVerify(
                 railId,
@@ -265,22 +265,22 @@ contract RailSettlementTest is Test, BaseTestHelper {
                 block.number
             );
 
-        // Verify arbiter note
+        // Verify validator note
         assertEq(
             result.note,
             "Standard approved payment",
-            "Arbiter note should match"
+            "Validator note should match"
         );
     }
 
-    function testArbitrationWithReducedAmount() public {
-        // Deploy an arbiter that reduces payment amounts
-        MockArbiter arbiter = new MockArbiter(
-            MockArbiter.ArbiterMode.REDUCE_AMOUNT
+    function testValidationWithReducedAmount() public {
+        // Deploy an validator that reduces payment amounts
+        MockValidator validator = new MockValidator(
+            MockValidator.ValidatorMode.REDUCE_AMOUNT
         );
-        arbiter.configure(80); // 80% of the original amount
+        validator.configure(80); // 80% of the original amount
 
-        // Create a rail with the arbiter
+        // Create a rail with the validator
         uint256 rate = 10 ether;
         uint256 railId = helper.setupRailWithParameters(
             USER1,
@@ -289,7 +289,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(arbiter) // Reduced amount arbiter
+            address(validator) // Reduced amount validator
         );
 
         // Advance several blocks
@@ -298,7 +298,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
         // Verify reduced amount (80% of original)
         uint256 expectedAmount = (rate * 5 * 80) / 100; // 5 blocks * 10 ether * 80%
 
-        // Calculate expected contract fee (1% of the arbitrated amount)
+        // Calculate expected contract fee (1% of the validated amount)
         uint256 paymentFee = (expectedAmount * payments.PAYMENT_FEE_BPS()) /
             payments.COMMISSION_MAX_BPS();
         uint256 netPayeeAmount = expectedAmount - paymentFee;
@@ -306,7 +306,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
         // Capture fee balance before settlement
         uint256 feesBefore = payments.accumulatedFees(address(token));
 
-        // Settle with arbitration - verify against NET payee amount
+        // Settle with validation - verify against NET payee amount
         RailSettlementHelpers.SettlementResult memory result = settlementHelper
             .settleRailAndVerify(
                 railId,
@@ -330,22 +330,22 @@ contract RailSettlementTest is Test, BaseTestHelper {
         assertEq(result.paymentFee, paymentFee, "Payment fee incorrect");
         assertEq(result.operatorCommission, 0, "Operator commission incorrect");
 
-        // Verify arbiter note
+        // Verify validator note
         assertEq(
             result.note,
-            "Arbiter reduced payment amount",
-            "Arbiter note should match"
+            "Validator reduced payment amount",
+            "Validator note should match"
         );
     }
 
-    function testArbitrationWithReducedDuration() public {
-        // Deploy an arbiter that reduces settlement duration
-        MockArbiter arbiter = new MockArbiter(
-            MockArbiter.ArbiterMode.REDUCE_DURATION
+    function testValidationWithReducedDuration() public {
+        // Deploy an validator that reduces settlement duration
+        MockValidator validator = new MockValidator(
+            MockValidator.ValidatorMode.REDUCE_DURATION
         );
-        arbiter.configure(60); // 60% of the original duration
+        validator.configure(60); // 60% of the original duration
 
-        // Create a rail with the arbiter
+        // Create a rail with the validator
         uint256 rate = 10 ether;
         uint256 railId = helper.setupRailWithParameters(
             USER1,
@@ -354,7 +354,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(arbiter) // Reduced duration arbiter
+            address(validator) // Reduced duration validator
         );
 
         // Advance several blocks
@@ -368,7 +368,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
             expectedDuration;
         uint256 expectedAmount = rate * expectedDuration; // expectedDuration blocks * 10 ether
 
-        // Settle with arbitration
+        // Settle with validation
         RailSettlementHelpers.SettlementResult memory result = settlementHelper
             .settleRailAndVerify(
                 railId,
@@ -377,21 +377,21 @@ contract RailSettlementTest is Test, BaseTestHelper {
                 expectedSettledUpto
             );
 
-        // Verify arbiter note
+        // Verify validator note
         assertEq(
             result.note,
-            "Arbiter reduced settlement duration",
-            "Arbiter note should match"
+            "Validator reduced settlement duration",
+            "Validator note should match"
         );
     }
 
-    function testMaliciousArbiterHandling() public {
-        // Deploy a malicious arbiter
-        MockArbiter arbiter = new MockArbiter(
-            MockArbiter.ArbiterMode.MALICIOUS
+    function testMaliciousValidatorHandling() public {
+        // Deploy a malicious validator
+        MockValidator validator = new MockValidator(
+            MockValidator.ValidatorMode.MALICIOUS
         );
 
-        // Create a rail with the arbiter
+        // Create a rail with the validator
         uint256 rate = 5 ether;
         uint256 railId = helper.setupRailWithParameters(
             USER1,
@@ -400,22 +400,22 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(arbiter) // Malicious arbiter
+            address(validator) // Malicious validator
         );
 
         // Advance several blocks
         helper.advanceBlocks(5);
 
-        // Attempt settlement with malicious arbiter - should revert
+        // Attempt settlement with malicious validator - should revert
         vm.prank(USER1);
-        vm.expectRevert("arbiter settled beyond segment end");
+        vm.expectRevert("validator settled beyond segment end");
         payments.settleRail(railId, block.number);
 
-        // Set the arbiter to return invalid amount but valid settlement duration
-        arbiter.setMode(MockArbiter.ArbiterMode.CUSTOM_RETURN);
+        // Set the validator to return invalid amount but valid settlement duration
+        validator.setMode(MockValidator.ValidatorMode.CUSTOM_RETURN);
         uint256 proposedAmount = rate * 5; // 5 blocks * 5 ether
         uint256 invalidAmount = proposedAmount * 2; // Double the correct amount
-        arbiter.setCustomValues(
+        validator.setCustomValues(
             invalidAmount,
             block.number,
             "Attempting excessive payment"
@@ -424,7 +424,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
         // Attempt settlement with excessive amount - should also revert
         vm.prank(USER1);
         vm.expectRevert(
-            "arbiter modified amount exceeds maximum for settled duration"
+            "validator modified amount exceeds maximum for settled duration"
         );
         payments.settleRail(railId, block.number);
     }
@@ -443,7 +443,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             lockupPeriod, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0) // No validator
         );
 
         // Advance several blocks
@@ -540,7 +540,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             10, // lockupPeriod
             0, // No fixed lockup
-            address(0) // No arbiter
+            address(0) // No validator
         );
 
         // Settle immediately without advancing blocks - should be a no-op
@@ -563,13 +563,13 @@ contract RailSettlementTest is Test, BaseTestHelper {
         );
     }
 
-    function testSettleRailWithRateChangeQueueForReducedAmountArbitration() public {
-        // Deploy an arbiter that reduces the payment amount by a percentage
+    function testSettleRailWithRateChangeQueueForReducedAmountValidation() public {
+        // Deploy an validator that reduces the payment amount by a percentage
         uint256 factor = 80; // 80% of the original amount
-        MockArbiter arbiter = new MockArbiter(MockArbiter.ArbiterMode.REDUCE_AMOUNT);
-        arbiter.configure(factor);
+        MockValidator validator = new MockValidator(MockValidator.ValidatorMode.REDUCE_AMOUNT);
+        validator.configure(factor);
 
-        // Create a rail with the arbiter
+        // Create a rail with the validator
         uint256 rate = 5 ether;
         uint256 lockupPeriod = 10;
         uint256 railId = helper.setupRailWithParameters(
@@ -579,7 +579,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             lockupPeriod, 
             0, // No fixed lockup
-            address(arbiter)
+            address(validator)
         );
 
         // Simulate 5 blocks passing (blocks 1-5)
@@ -607,9 +607,9 @@ contract RailSettlementTest is Test, BaseTestHelper {
         helper.advanceBlocks(5);
 
         // Calculate expected settlement:
-        // Phase 1 (blocks 1-5): 5 blocks at 5 ETH/block → 25 ETH total -> after arbitration (80%) -> 20 ETH total
-        // Phase 2 (blocks 6-10): 5 blocks at 10 ETH/block → 50 ETH total -> after arbitration (80%) -> 40 ETH total
-        // Total after arbitration (80%) -> 60 ETH total
+        // Phase 1 (blocks 1-5): 5 blocks at 5 ETH/block → 25 ETH total -> after validation (80%) -> 20 ETH total
+        // Phase 2 (blocks 6-10): 5 blocks at 10 ETH/block → 50 ETH total -> after validation (80%) -> 40 ETH total
+        // Total after validation (80%) -> 60 ETH total
         uint256 expectedDurationOldRate = 5; // Epochs 1-5 ( rate = 5 )
         uint256 expectedDurationNewRate = 5; // Epochs 6-10 ( rate = 10 )
         uint256 expectedAmountOldRate = (rate * expectedDurationOldRate * factor ) / 100; // 20 ETH (25 * 0.8)
@@ -623,13 +623,13 @@ contract RailSettlementTest is Test, BaseTestHelper {
         console.log("result.note", result.note);
     }
 
-    function testSettleRailWithRateChangeQueueForReducedDurationArbitration() public {
-        // Deploy an arbiter that reduces the duration by a percentage
+    function testSettleRailWithRateChangeQueueForReducedDurationValidation() public {
+        // Deploy an validator that reduces the duration by a percentage
         uint256 factor = 60; // 60% of the original duration
-        MockArbiter arbiter = new MockArbiter(MockArbiter.ArbiterMode.REDUCE_DURATION);
-        arbiter.configure(factor);
+        MockValidator validator = new MockValidator(MockValidator.ValidatorMode.REDUCE_DURATION);
+        validator.configure(factor);
 
-        // Create a rail with the arbiter
+        // Create a rail with the validator
         uint256 rate = 5 ether;
         uint256 lockupPeriod = 10;
         uint256 railId = helper.setupRailWithParameters(
@@ -639,7 +639,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
             rate,
             lockupPeriod,
             0, // No fixed lockup
-            address(arbiter)
+            address(validator)
         );
 
         // Simulate 5 blocks passing (blocks 1-5)
@@ -651,7 +651,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
         // LastSettledUpto: 1 + (6 - 1) * 60% = 4
         vm.prank(USER1);
         payments.settleRail(railId, block.number);
-        uint256 lastSettledUpto = 1 + ((block.number - 1) * factor) / 100; // arbiter only settles for 60% of the duration (block.number - lastSettledUpto = epoch 1)
+        uint256 lastSettledUpto = 1 + ((block.number - 1) * factor) / 100; // validator only settles for 60% of the duration (block.number - lastSettledUpto = epoch 1)
         vm.stopPrank();
 
 
@@ -725,7 +725,7 @@ contract RailSettlementTest is Test, BaseTestHelper {
             address(token),
             USER1,
             USER2,
-            address(0), // no arbiter
+            address(0), // no validator
             operatorCommissionBps
         );
         vm.stopPrank();

--- a/test/helpers/BaseTestHelper.sol
+++ b/test/helpers/BaseTestHelper.sol
@@ -9,12 +9,12 @@ contract BaseTestHelper is Test {
     uint256 internal user2Sk = 3;
     uint256 internal operatorSk = 4;
     uint256 internal operator2Sk = 5;
-    uint256 internal arbiterSk = 6;
+    uint256 internal validatorSk = 6;
 
     address public immutable OWNER = vm.addr(ownerSk);
     address public immutable USER1 = vm.addr(user1Sk);
     address public immutable USER2 = vm.addr(user2Sk);
     address public immutable OPERATOR = vm.addr(operatorSk);
     address public immutable OPERATOR2 = vm.addr(operator2Sk);
-    address public immutable ARBITER = vm.addr(arbiterSk);
+    address public immutable VALIDATOR = vm.addr(validatorSk);
 }

--- a/test/helpers/PaymentsTestHelpers.sol
+++ b/test/helpers/PaymentsTestHelpers.sol
@@ -36,7 +36,7 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         users[2] = USER2;
         users[3] = OPERATOR;
         users[4] = OPERATOR2;
-        users[5] = ARBITER;
+        users[5] = VALIDATOR;
 
         vm.deal(USER1, INITIAL_BALANCE);
         vm.deal(USER2, INITIAL_BALANCE);
@@ -405,14 +405,14 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         address from,
         address to,
         address railOperator,
-        address arbiter
+        address validator
     ) public returns (uint256) {
         vm.startPrank(railOperator);
         uint256 railId = payments.createRail(
             address(testToken),
             from,
             to,
-            arbiter,
+            validator,
             0 // commissionRateBps
         );
         vm.stopPrank();
@@ -422,7 +422,7 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         assertEq(rail.token, address(testToken), "Rail token address mismatch");
         assertEq(rail.from, from, "Rail sender address mismatch");
         assertEq(rail.to, to, "Rail recipient address mismatch");
-        assertEq(rail.arbiter, arbiter, "Rail arbiter address mismatch");
+        assertEq(rail.validator, validator, "Rail validator address mismatch");
         assertEq(rail.operator, railOperator, "Rail operator address mismatch");
 
         return railId;
@@ -435,7 +435,7 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         uint256 paymentRate,
         uint256 lockupPeriod,
         uint256 lockupFixed,
-        address arbiter
+        address validator
     ) public returns (uint256 railId) {
         // Calculate required allowances for the rail
         uint256 requiredRateAllowance = paymentRate;
@@ -473,7 +473,7 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
             vm.stopPrank();
         }
 
-        railId = createRail(from, to, railOperator, arbiter);
+        railId = createRail(from, to, railOperator, validator);
 
         // Get operator usage before modifications
         (, , , uint256 rateUsageBefore, uint256 lockupUsageBefore,) = payments
@@ -507,7 +507,7 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
             "Rail lockup period mismatch"
         );
         assertEq(rail.lockupFixed, lockupFixed, "Rail fixed lockup mismatch");
-        assertEq(rail.arbiter, arbiter, "Rail arbiter address mismatch");
+        assertEq(rail.validator, validator, "Rail validator address mismatch");
 
         // Get operator usage after modifications
         (, , , uint256 rateUsageAfter, uint256 lockupUsageAfter, ) = payments

--- a/test/helpers/RailSettlementHelpers.sol
+++ b/test/helpers/RailSettlementHelpers.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
-import {Payments, IArbiter} from "../../src/Payments.sol";
-import {MockArbiter} from "../mocks/MockArbiter.sol";
+import {Payments} from "../../src/Payments.sol";
+import {MockValidator} from "../mocks/MockValidator.sol";
 import {PaymentsTestHelpers} from "./PaymentsTestHelpers.sol";
 import {console} from "forge-std/console.sol";
 
@@ -32,19 +32,19 @@ contract RailSettlementHelpers is Test {
         string note;
     }
 
-    function setupRailWithArbitrerAndRateChangeQueue(
+    function setupRailWithValidatorAndRateChangeQueue(
         address from,
         address to,
         address operator,
-        address arbiter,
+        address validator,
         uint256[] memory rates,
         uint256 lockupPeriod,
         uint256 lockupFixed,
         uint256 maxLokkupPeriod
     ) public returns (uint256) {
         require(
-            arbiter != address(0),
-            "RailSettlementHelpers: arbiter cannot be zero address"
+            validator != address(0),
+            "RailSettlementHelpers: validator cannot be zero address"
         );
 
         // Setup operator approval with sufficient allowances
@@ -75,7 +75,7 @@ contract RailSettlementHelpers is Test {
             rates[0], // Initial rate
             lockupPeriod,
             lockupFixed,
-            arbiter
+            validator
         );
 
         // Apply rate changes for the rest of the rates
@@ -120,10 +120,10 @@ contract RailSettlementHelpers is Test {
         return railId;
     }
 
-    function deployMockArbiter(
-        MockArbiter.ArbiterMode mode
-    ) public returns (MockArbiter) {
-        return new MockArbiter(mode);
+    function deployMockValidator(
+        MockValidator.ValidatorMode mode
+    ) public returns (MockValidator) {
+        return new MockValidator(mode);
     }
 
     function settleRailAndVerify(

--- a/test/mocks/MockValidator.sol
+++ b/test/mocks/MockValidator.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {Payments, IArbiter} from "../../src/Payments.sol";
+import {Payments, IValidator} from "../../src/Payments.sol";
 
-contract MockArbiter is IArbiter {
-    enum ArbiterMode {
+contract MockValidator is IValidator {
+    enum ValidatorMode {
         STANDARD, // Approves all payments as proposed
         REDUCE_AMOUNT, // Reduces payment amount by a percentage
         REDUCE_DURATION, // Settles for fewer epochs than requested
@@ -12,13 +12,13 @@ contract MockArbiter is IArbiter {
         MALICIOUS // Returns invalid values
     }
 
-    ArbiterMode public mode = ArbiterMode.STANDARD; // Default to STANDARD mode
+    ValidatorMode public mode = ValidatorMode.STANDARD; // Default to STANDARD mode
     uint256 public modificationFactor; // Percentage (0-100) for reductions
     uint256 public customAmount;
     uint256 public customUpto;
     string public customNote;
 
-    constructor(ArbiterMode _mode) {
+    constructor(ValidatorMode _mode) {
         mode = _mode;
         modificationFactor = 100; // 100% = no modification by default
     }
@@ -39,34 +39,34 @@ contract MockArbiter is IArbiter {
         customNote = _note;
     }
 
-    // Change the arbiter's mode
-    function setMode(ArbiterMode _mode) external {
+    // Change the validator's mode
+    function setMode(ValidatorMode _mode) external {
         mode = _mode;
     }
 
-    function arbitratePayment(
+    function validatePayment(
         uint256 /* railId */,
         uint256 proposedAmount,
         uint256 fromEpoch,
         uint256 toEpoch,
         uint256 /* rate */
-    ) external view override returns (ArbitrationResult memory result) {
-        if (mode == ArbiterMode.STANDARD) {
+    ) external view override returns (ValidationResult memory result) {
+        if (mode == ValidatorMode.STANDARD) {
             return
-                ArbitrationResult({
+                ValidationResult({
                     modifiedAmount: proposedAmount,
                     settleUpto: toEpoch,
                     note: "Standard approved payment"
                 });
-        } else if (mode == ArbiterMode.REDUCE_AMOUNT) {
+        } else if (mode == ValidatorMode.REDUCE_AMOUNT) {
             uint256 reducedAmount = (proposedAmount * modificationFactor) / 100;
             return
-                ArbitrationResult({
+                ValidationResult({
                     modifiedAmount: reducedAmount,
                     settleUpto: toEpoch,
-                    note: "Arbiter reduced payment amount"
+                    note: "Validator reduced payment amount"
                 });
-        } else if (mode == ArbiterMode.REDUCE_DURATION) {
+        } else if (mode == ValidatorMode.REDUCE_DURATION) {
             uint256 totalEpochs = toEpoch - fromEpoch;
             uint256 reducedEpochs = (totalEpochs * modificationFactor) / 100;
             uint256 reducedEndEpoch = fromEpoch + reducedEpochs;
@@ -76,14 +76,14 @@ contract MockArbiter is IArbiter {
                 totalEpochs;
 
             return
-                ArbitrationResult({
+                ValidationResult({
                     modifiedAmount: reducedAmount,
                     settleUpto: reducedEndEpoch,
-                    note: "Arbiter reduced settlement duration"
+                    note: "Validator reduced settlement duration"
                 });
-        } else if (mode == ArbiterMode.CUSTOM_RETURN) {
+        } else if (mode == ValidatorMode.CUSTOM_RETURN) {
             return
-                ArbitrationResult({
+                ValidationResult({
                     modifiedAmount: customAmount,
                     settleUpto: customUpto,
                     note: customNote
@@ -91,10 +91,10 @@ contract MockArbiter is IArbiter {
         } else {
             // Malicious mode attempts to return invalid values
             return
-                ArbitrationResult({
+                ValidationResult({
                     modifiedAmount: proposedAmount * 2, // Try to double the payment
                     settleUpto: toEpoch + 10, // Try to settle beyond the requested range
-                    note: "Malicious arbiter attempting to manipulate payment"
+                    note: "Malicious validator attempting to manipulate payment"
                 });
         }
     }


### PR DESCRIPTION
Fixes: #107 

The following PR includes the following changes - 

- Renamed all references of "Arbitration" to "Validation" across the codebase, including the Payments contract and tests.