### PR TITLE
Client should be able to do (ERC-20 approval + Deposit + Operator approval) in one tx

### DIFF
--- a/.gitattribute
+++ b/.gitattribute
@@ -1,0 +1,3 @@
+# Normalize line endings for Solidity files in src and test
+src/**/*.sol text eol=lf
+test/**/*.sol text eol=lf

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Deposits tokens using EIP-2612 permit.
   - Caller must have signed the permit
   - Permit must be valid and not expired
 
-#### `depositWithPermitAndOperatorApproval(address token, address to, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s, address operator, bool approved, uint256 rateAllowance, uint256 lockupAllowance, uint256 maxLockupPeriod)`
+#### `depositWithPermitAndApproveOperator(address token, address to, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s, address operator, uint256 rateAllowance, uint256 lockupAllowance, uint256 maxLockupPeriod)`
 
 Deposits tokens using EIP-2612 permit and sets operator approval in a single transaction.
 
@@ -97,7 +97,6 @@ Deposits tokens using EIP-2612 permit and sets operator approval in a single tra
   - `deadline`: Permit expiration timestamp
   - `v`, `r`, `s`: Signature components for EIP-2612 permit signature
   - `operator`: Address to grant permissions to
-  - `approved`: Whether the operator is approved
   - `rateAllowance`: Maximum payment rate the operator can set across all rails
   - `lockupAllowance`: Maximum funds the operator can lock for future payments
   - `maxLockupPeriod`: Maximum allowed lockup period in epochs

--- a/README.md
+++ b/README.md
@@ -70,6 +70,38 @@ Deposits tokens into a specified account.
 - **Requirements**:
   - Caller must have approved the contract to transfer tokens
 
+#### `depositWithPermit(address token, address to, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s)`
+
+Deposits tokens using EIP-2612 permit.
+
+- **Parameters**:
+  - `token`: ERC20 token contract address supporting EIP-2612 permits
+  - `to`: Recipient account address (must be the signer of the permit)
+  - `amount`: Token amount to deposit
+  - `deadline`: Permit expiration timestamp
+  - `v`, `r`, `s`: Signature components for EIP-2612 permit signature
+
+- **Requirements**:
+  - Token must support EIP-2612 permit
+  - Caller must have signed the permit
+  - Permit must be valid and not expired
+
+#### `depositWithPermitAndOperatorApproval(address token, address to, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s, address operator, bool approved, uint256 rateAllowance, uint256 lockupAllowance, uint256 maxLockupPeriod)`
+
+Deposits tokens using EIP-2612 permit and sets operator approval in a single transaction.
+
+- **Parameters**:
+  - `token`: ERC20 token contract address supporting EIP-2612 permits
+  - `to`: Recipient account address (must be the signer of the permit)
+  - `amount`: Token amount to deposit
+  - `deadline`: Permit expiration timestamp
+  - `v`, `r`, `s`: Signature components for EIP-2612 permit signature
+  - `operator`: Address to grant permissions to
+  - `approved`: Whether the operator is approved
+  - `rateAllowance`: Maximum payment rate the operator can set across all rails
+  - `lockupAllowance`: Maximum funds the operator can lock for future payments
+  - `maxLockupPeriod`: Maximum allowed lockup period in epochs
+
 #### `withdraw(address token, uint256 amount)`
 
 Withdraws available tokens from caller's account to caller's wallet.
@@ -93,7 +125,7 @@ Withdraws available tokens from caller's account to a specified address.
 
 ### Operator Management
 
-#### `setOperatorApproval(address token, address operator, bool approved, uint256 rateAllowance, uint256 lockupAllowance)`
+#### `setOperatorApproval(address token, address operator, bool approved, uint256 rateAllowance, uint256 lockupAllowance, uint256 maxLockupPeriod)`
 
 Configures an operator's permissions to manage rails on behalf of the caller.
 
@@ -103,6 +135,7 @@ Configures an operator's permissions to manage rails on behalf of the caller.
   - `approved`: Whether the operator is approved
   - `rateAllowance`: Maximum payment rate the operator can set across all rails
   - `lockupAllowance`: Maximum funds the operator can lock for future payments
+  - `maxLockupPeriod`: Maximum allowed lockup period in epochs
 
 ### Rail Management
 

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -276,7 +276,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
     /// @notice Updates the approval status and allowances for an operator on behalf of the message sender.
     /// @param token The ERC20 token address for which the approval is being set.
     /// @param operator The address of the operator whose approval is being modified.
-    /// @param approved Whether the operator is approved (true) or not (false) to create new rails>
+    /// @param approved Whether the operator is approved (true) or not (false) to create new rails.
     /// @param rateAllowance The maximum payment rate the operator can set across all rails created by the operator on behalf of the message sender. If this is less than the current payment rate, the operator will only be able to reduce rates until they fall below the target.
     /// @param lockupAllowance The maximum amount of funds the operator can lock up on behalf of the message sender towards future payments. If this exceeds the current total amount of funds locked towards future payments, the operator will only be able to reduce future lockup.
     /// @param maxLockupPeriod The maximum number of epochs (blocks) the operator can lock funds for. If this is less than the current lockup period for a rail, the operator will only be able to reduce the lockup period.
@@ -404,10 +404,10 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
      * @param operator The address of the operator whose approval is being modified.
      * @param approved Whether the operator is approved (true) or not (false) to create new rails.
      * @param rateAllowance The maximum payment rate the operator can set across all rails created by the operator
-     *             on behalf of the message sender. If this is less than the current payment rate, the operator will 
+     *             on behalf of the message sender. If this is less than the current payment rate, the operator will
      *             only be able to reduce rates until they fall below the target.
      * @param lockupAllowance The maximum amount of funds the operator can lock up on behalf of the message sender
-     *             towards future payments. If this exceeds the current total amount of funds locked towards future payments, 
+     *             towards future payments. If this exceeds the current total amount of funds locked towards future payments,
      *             the operator will only be able to reduce future lockup.
      * @param maxLockupPeriod The maximum number of epochs (blocks) the operator can lock funds for. If this is less than
      *             the current lockup period for a rail, the operator will only be able to reduce the lockup period.

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -287,7 +287,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
         uint256 rateAllowance,
         uint256 lockupAllowance,
         uint256 maxLockupPeriod
-    ) external nonReentrant validateNonZeroAddress(operator, "operator") {
+    ) public nonReentrant validateNonZeroAddress(operator, "operator") {
         OperatorApproval storage approval = operatorApprovals[token][msg.sender][operator];
 
         // Update approval status and allowances
@@ -378,7 +378,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external nonReentrant validateNonZeroAddress(to, "to") settleAccountLockupBeforeAndAfter(token, to, false) {
+    ) public nonReentrant validateNonZeroAddress(to, "to") settleAccountLockupBeforeAndAfter(token, to, false) {
         // Revert if token is address(0) as permit is not supported for native tokens
         require(token != address(0), "depositWithPermit: native token not supported");
 
@@ -390,6 +390,44 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
         account.funds += amount;
 
         emit DepositWithPermit(token, to, amount);
+    }
+
+    /**
+     * @notice Deposits tokens using permit (EIP-2612) approval in a single transaction,
+     *         while also setting operator approval.
+     * @param token The ERC20 token address to deposit and for which the operator approval is being set.
+     *             Note: The token must support EIP-2612 permit functionality.
+     * @param to The address whose account will be credited (must be the permit signer).
+     * @param amount The amount of tokens to deposit.
+     * @param deadline Permit deadline (timestamp).
+     * @param v,r,s Permit signature.
+     * @param operator The address of the operator whose approval is being modified.
+     * @param approved Whether the operator is approved (true) or not (false) to create new rails.
+     * @param rateAllowance The maximum payment rate the operator can set across all rails created by the operator
+     *             on behalf of the message sender. If this is less than the current payment rate, the operator will 
+     *             only be able to reduce rates until they fall below the target.
+     * @param lockupAllowance The maximum amount of funds the operator can lock up on behalf of the message sender
+     *             towards future payments. If this exceeds the current total amount of funds locked towards future payments, 
+     *             the operator will only be able to reduce future lockup.
+     * @param maxLockupPeriod The maximum number of epochs (blocks) the operator can lock funds for. If this is less than
+     *             the current lockup period for a rail, the operator will only be able to reduce the lockup period.
+     */
+    function depositWithPermitAndOperatorApproval(
+        address token,
+        address to,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        address operator,
+        bool approved,
+        uint256 rateAllowance,
+        uint256 lockupAllowance,
+        uint256 maxLockupPeriod
+    ) external {
+        setOperatorApproval(token, operator, approved, rateAllowance, lockupAllowance, maxLockupPeriod);
+        depositWithPermit(token, to, amount, deadline, v, r, s);
     }
 
     /// @notice Withdraws tokens from the caller's account to the caller's account, up to the amount of currently available tokens (the tokens not currently locked in rails).

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1342,7 +1342,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
 
         // Perform the transfer
         if (token == address(0)) {
-            (bool success, ) = payable(to).call{value: amount}("");
+            (bool success,) = payable(to).call{value: amount}("");
             require(success, "FIL transfer failed");
         } else {
             IERC20(token).safeTransfer(to, amount);

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -287,7 +287,18 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
         uint256 rateAllowance,
         uint256 lockupAllowance,
         uint256 maxLockupPeriod
-    ) public nonReentrant validateNonZeroAddress(operator, "operator") {
+    ) external nonReentrant validateNonZeroAddress(operator, "operator") {
+        _setOperatorApproval(token, operator, approved, rateAllowance, lockupAllowance, maxLockupPeriod);
+    }
+
+    function _setOperatorApproval(
+        address token,
+        address operator,
+        bool approved,
+        uint256 rateAllowance,
+        uint256 lockupAllowance,
+        uint256 maxLockupPeriod
+    ) internal {
         OperatorApproval storage approval = operatorApprovals[token][msg.sender][operator];
 
         // Update approval status and allowances
@@ -378,7 +389,19 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) public nonReentrant validateNonZeroAddress(to, "to") settleAccountLockupBeforeAndAfter(token, to, false) {
+    ) external nonReentrant validateNonZeroAddress(to, "to") settleAccountLockupBeforeAndAfter(token, to, false) {
+        _depositWithPermit(token, to, amount, deadline, v, r, s);
+    }
+
+    function _depositWithPermit(
+        address token,
+        address to,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal {
         // Revert if token is address(0) as permit is not supported for native tokens
         require(token != address(0), "depositWithPermit: native token not supported");
 
@@ -402,7 +425,6 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
      * @param deadline Permit deadline (timestamp).
      * @param v,r,s Permit signature.
      * @param operator The address of the operator whose approval is being modified.
-     * @param approved Whether the operator is approved (true) or not (false) to create new rails.
      * @param rateAllowance The maximum payment rate the operator can set across all rails created by the operator
      *             on behalf of the message sender. If this is less than the current payment rate, the operator will
      *             only be able to reduce rates until they fall below the target.
@@ -412,7 +434,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
      * @param maxLockupPeriod The maximum number of epochs (blocks) the operator can lock funds for. If this is less than
      *             the current lockup period for a rail, the operator will only be able to reduce the lockup period.
      */
-    function depositWithPermitAndOperatorApproval(
+    function depositWithPermitAndApproveOperator(
         address token,
         address to,
         uint256 amount,
@@ -421,13 +443,18 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
         bytes32 r,
         bytes32 s,
         address operator,
-        bool approved,
         uint256 rateAllowance,
         uint256 lockupAllowance,
         uint256 maxLockupPeriod
-    ) external {
-        setOperatorApproval(token, operator, approved, rateAllowance, lockupAllowance, maxLockupPeriod);
-        depositWithPermit(token, to, amount, deadline, v, r, s);
+    )
+        external
+        nonReentrant
+        validateNonZeroAddress(operator, "operator")
+        validateNonZeroAddress(to, "to")
+        settleAccountLockupBeforeAndAfter(token, to, false)
+    {
+        _setOperatorApproval(token, operator, true, rateAllowance, lockupAllowance, maxLockupPeriod);
+        _depositWithPermit(token, to, amount, deadline, v, r, s);
     }
 
     /// @notice Withdraws tokens from the caller's account to the caller's account, up to the amount of currently available tokens (the tokens not currently locked in rails).

--- a/test/DepositWithPermitAndOperatorApproval.t.sol
+++ b/test/DepositWithPermitAndOperatorApproval.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {Payments} from "../src/Payments.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {PaymentsTestHelpers} from "./helpers/PaymentsTestHelpers.sol";
+import {BaseTestHelper} from "./helpers/BaseTestHelper.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {console} from "forge-std/console.sol";
+
+contract DepositWithPermitAndOperatorApproval is Test, BaseTestHelper {
+    MockERC20 testToken;
+    PaymentsTestHelpers helper;
+    Payments payments;
+
+    uint256 constant DEPOSIT_AMOUNT = 1000 ether;
+    uint256 constant RATE_ALLOWANCE = 100 ether;
+    uint256 constant LOCKUP_ALLOWANCE = 1000 ether;
+    uint256 constant MAX_LOCKUP_PERIOD = 100;
+    uint256 internal constant INITIAL_BALANCE = 1000 ether;
+
+
+    function setUp() public {
+        helper = new PaymentsTestHelpers();
+        helper.setupStandardTestEnvironment();
+        payments = helper.payments();
+
+        testToken = helper.testToken();
+    }
+
+    function testDepositWithPermitAndOperatorApproval_HappyPath() public {
+        helper.makeDepositWithPermitAndOperatorApproval(user1Sk, DEPOSIT_AMOUNT, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD);
+    }
+
+    function testDepositWithPermitAndOperatorApproval_ZeroAmount() public {
+        helper.makeDepositWithPermitAndOperatorApproval(user1Sk, 0, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD);
+    }
+
+    function testDepositWithPermitAndOperatorApproval_MultipleDeposits() public {
+        uint256 firstDepositAmount = 500 ether;
+        uint256 secondDepositAmount = 300 ether;
+
+        helper.makeDepositWithPermitAndOperatorApproval(user1Sk, firstDepositAmount, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD);
+        helper.makeDepositWithPermitAndOperatorApproval(user1Sk, secondDepositAmount, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD);
+    }
+
+    function testDepositWithPermitAndOperatorApproval_InvalidPermitReverts() public {
+        helper.expectInvalidPermitAndOperatorApprovalToRevert(
+            user1Sk,
+            DEPOSIT_AMOUNT,
+            OPERATOR,
+            true,
+            RATE_ALLOWANCE,
+            LOCKUP_ALLOWANCE,
+            MAX_LOCKUP_PERIOD
+        );
+        
+    }
+}

--- a/test/DepositWithPermitAndOperatorApproval.t.sol
+++ b/test/DepositWithPermitAndOperatorApproval.t.sol
@@ -20,7 +20,6 @@ contract DepositWithPermitAndOperatorApproval is Test, BaseTestHelper {
     uint256 constant MAX_LOCKUP_PERIOD = 100;
     uint256 internal constant INITIAL_BALANCE = 1000 ether;
 
-
     function setUp() public {
         helper = new PaymentsTestHelpers();
         helper.setupStandardTestEnvironment();
@@ -30,31 +29,32 @@ contract DepositWithPermitAndOperatorApproval is Test, BaseTestHelper {
     }
 
     function testDepositWithPermitAndOperatorApproval_HappyPath() public {
-        helper.makeDepositWithPermitAndOperatorApproval(user1Sk, DEPOSIT_AMOUNT, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD);
+        helper.makeDepositWithPermitAndOperatorApproval(
+            user1Sk, DEPOSIT_AMOUNT, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+        );
     }
 
     function testDepositWithPermitAndOperatorApproval_ZeroAmount() public {
-        helper.makeDepositWithPermitAndOperatorApproval(user1Sk, 0, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD);
+        helper.makeDepositWithPermitAndOperatorApproval(
+            user1Sk, 0, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+        );
     }
 
     function testDepositWithPermitAndOperatorApproval_MultipleDeposits() public {
         uint256 firstDepositAmount = 500 ether;
         uint256 secondDepositAmount = 300 ether;
 
-        helper.makeDepositWithPermitAndOperatorApproval(user1Sk, firstDepositAmount, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD);
-        helper.makeDepositWithPermitAndOperatorApproval(user1Sk, secondDepositAmount, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD);
+        helper.makeDepositWithPermitAndOperatorApproval(
+            user1Sk, firstDepositAmount, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+        );
+        helper.makeDepositWithPermitAndOperatorApproval(
+            user1Sk, secondDepositAmount, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+        );
     }
 
     function testDepositWithPermitAndOperatorApproval_InvalidPermitReverts() public {
         helper.expectInvalidPermitAndOperatorApprovalToRevert(
-            user1Sk,
-            DEPOSIT_AMOUNT,
-            OPERATOR,
-            true,
-            RATE_ALLOWANCE,
-            LOCKUP_ALLOWANCE,
-            MAX_LOCKUP_PERIOD
+            user1Sk, DEPOSIT_AMOUNT, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
         );
-        
     }
 }

--- a/test/DepositWithPermitAndOperatorApproval.t.sol
+++ b/test/DepositWithPermitAndOperatorApproval.t.sol
@@ -30,13 +30,13 @@ contract DepositWithPermitAndOperatorApproval is Test, BaseTestHelper {
 
     function testDepositWithPermitAndOperatorApproval_HappyPath() public {
         helper.makeDepositWithPermitAndOperatorApproval(
-            user1Sk, DEPOSIT_AMOUNT, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+            user1Sk, DEPOSIT_AMOUNT, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
         );
     }
 
     function testDepositWithPermitAndOperatorApproval_ZeroAmount() public {
         helper.makeDepositWithPermitAndOperatorApproval(
-            user1Sk, 0, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+            user1Sk, 0, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
         );
     }
 
@@ -45,16 +45,16 @@ contract DepositWithPermitAndOperatorApproval is Test, BaseTestHelper {
         uint256 secondDepositAmount = 300 ether;
 
         helper.makeDepositWithPermitAndOperatorApproval(
-            user1Sk, firstDepositAmount, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+            user1Sk, firstDepositAmount, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
         );
         helper.makeDepositWithPermitAndOperatorApproval(
-            user1Sk, secondDepositAmount, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+            user1Sk, secondDepositAmount, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
         );
     }
 
     function testDepositWithPermitAndOperatorApproval_InvalidPermitReverts() public {
         helper.expectInvalidPermitAndOperatorApprovalToRevert(
-            user1Sk, DEPOSIT_AMOUNT, OPERATOR, true, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
+            user1Sk, DEPOSIT_AMOUNT, OPERATOR, RATE_ALLOWANCE, LOCKUP_ALLOWANCE, MAX_LOCKUP_PERIOD
         );
     }
 }

--- a/test/helpers/PaymentsTestHelpers.sol
+++ b/test/helpers/PaymentsTestHelpers.sol
@@ -732,7 +732,6 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         uint256 fromPrivateKey,
         uint256 amount,
         address operator,
-        bool approved,
         uint256 rateAllowance,
         uint256 lockupAllowance,
         uint256 maxLockupPeriod
@@ -752,7 +751,7 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         // Execute deposit with permit
         vm.startPrank(from);
 
-        payments.depositWithPermitAndOperatorApproval(
+        payments.depositWithPermitAndApproveOperator(
             address(testToken),
             from,
             amount,
@@ -761,7 +760,6 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
             r,
             s,
             operator,
-            approved,
             rateAllowance,
             lockupAllowance,
             maxLockupPeriod
@@ -785,14 +783,13 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
             amount
         );
 
-        verifyOperatorAllowances(from, operator, approved, rateAllowance, lockupAllowance, 0, 0, maxLockupPeriod);
+        verifyOperatorAllowances(from, operator, true, rateAllowance, lockupAllowance, 0, 0, maxLockupPeriod);
     }
 
     function expectInvalidPermitAndOperatorApprovalToRevert(
         uint256 senderSk,
         uint256 amount,
         address operator,
-        bool approved,
         uint256 rateAllowance,
         uint256 lockupAllowance,
         uint256 maxLockupPeriod
@@ -815,7 +812,7 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
 
         // Expect custom error: ERC2612InvalidSigner(wrongRecovered, expectedOwner)
         vm.expectRevert(abi.encodeWithSignature("ERC2612InvalidSigner(address,address)", vm.addr(notSenderSk), from));
-        payments.depositWithPermitAndOperatorApproval(
+        payments.depositWithPermitAndApproveOperator(
             address(testToken),
             from,
             amount,
@@ -824,7 +821,6 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
             r,
             s,
             operator,
-            approved,
             rateAllowance,
             lockupAllowance,
             maxLockupPeriod

--- a/test/helpers/PaymentsTestHelpers.sol
+++ b/test/helpers/PaymentsTestHelpers.sol
@@ -17,7 +17,7 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
     uint256 internal constant MAX_LOCKUP_PERIOD = 100;
 
     Payments public payments;
-    IERC20 public testToken;
+    MockERC20 public testToken;
 
     // Standard test environment setup with common addresses and token
     function setupStandardTestEnvironment() public {
@@ -126,14 +126,42 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         Payments.Account memory toAccountAfter = _getAccountData(to, false);
 
         // Asserts / Checks
+        _assertDepositBalances(
+            fromBalanceBefore,
+            fromBalanceAfter,
+            paymentsBalanceBefore,
+            paymentsBalanceAfter,
+            toAccountBefore,
+            toAccountAfter,
+            amount
+        );
+    }
+
+    function _assertDepositBalances(
+        uint256 fromBalanceBefore,
+        uint256 fromBalanceAfter,
+        uint256 paymentsBalanceBefore,
+        uint256 paymentsBalanceAfter,
+        Payments.Account memory toAccountBefore,
+        Payments.Account memory toAccountAfter,
+        uint256 amount
+    ) private pure {
         assertEq(fromBalanceAfter, fromBalanceBefore - amount, "Sender's balance not reduced correctly");
         assertEq(
             paymentsBalanceAfter, paymentsBalanceBefore + amount, "Payments contract balance not increased correctly"
         );
+
         assertEq(
-            toAccountAfter.funds, toAccountBefore.funds + amount, "Recipient's account balance not increased correctly"
+            paymentsBalanceAfter,
+            paymentsBalanceBefore + amount,
+            "Payments contract balance not increased correctly"
         );
-        console.log("toAccountAfter.funds", toAccountAfter.funds);
+        
+        assertEq(
+            toAccountAfter.funds,
+            toAccountBefore.funds + amount,
+            "Recipient's account balance not increased correctly"
+        );
     }
 
     function getAccountData(address user) public view returns (Payments.Account memory) {
@@ -247,7 +275,7 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         );
     }
 
-    function _balanceOf(address addr, bool useNativeToken) private returns (uint256) {
+    function _balanceOf(address addr, bool useNativeToken) private view returns (uint256) {
         if (useNativeToken) {
             return addr.balance;
         } else {
@@ -702,5 +730,142 @@ contract PaymentsTestHelpers is Test, BaseTestHelper {
         vm.expectRevert(abi.encodeWithSignature("ERC2612InvalidSigner(address,address)", vm.addr(notSenderSk), from));
         payments.depositWithPermit(address(testToken), to, amount, deadline, v, r, s);
         vm.stopPrank();
+    }
+
+    function makeDepositWithPermitAndOperatorApproval(
+        uint256 fromPrivateKey,
+        uint256 amount,
+        address operator,
+        bool approved,
+        uint256 rateAllowance,
+        uint256 lockupAllowance,
+        uint256 maxLockupPeriod
+    ) public {
+        address from = vm.addr(fromPrivateKey);
+        address to = from; 
+        uint256 deadline = block.timestamp + 1 hours;
+
+        // Capture pre-deposit balances and state
+        uint256 fromBalanceBefore = _balanceOf(from, false);
+        uint256 paymentsBalanceBefore = _balanceOf(address(payments), false);
+        Payments.Account memory toAccountBefore = _getAccountData(to, false);
+
+        // get signature for permit
+        (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
+            fromPrivateKey,
+            from,
+            address(payments),
+            amount,
+            deadline
+        );
+
+        // Execute deposit with permit
+        vm.startPrank(from);
+
+        payments.depositWithPermitAndOperatorApproval(
+            address(testToken),
+            from,
+            amount,
+            deadline,
+            v,
+            r,
+            s,
+            operator,
+            approved,
+            rateAllowance,
+            lockupAllowance,
+            maxLockupPeriod
+        );
+
+        vm.stopPrank();
+
+        // Capture post-deposit balances and state
+        uint256 fromBalanceAfter = _balanceOf(from, false);
+        uint256 paymentsBalanceAfter = _balanceOf(address(payments), false);
+        Payments.Account memory toAccountAfter = _getAccountData(to, false);
+
+        // Asserts / Checks
+        _assertDepositBalances(fromBalanceBefore, fromBalanceAfter, paymentsBalanceBefore, paymentsBalanceAfter, toAccountBefore, toAccountAfter, amount);
+
+        verifyOperatorAllowances(
+            from,
+            operator,
+            approved,
+            rateAllowance,
+            lockupAllowance,
+            0,
+            0,
+            maxLockupPeriod
+        );
+    }
+
+    function expectInvalidPermitAndOperatorApprovalToRevert(
+        uint256 senderSk,
+        uint256 amount,
+        address operator,
+        bool approved,
+        uint256 rateAllowance,
+        uint256 lockupAllowance,
+        uint256 maxLockupPeriod
+    ) public {
+        uint256 deadline = block.timestamp + 1 hours;
+        address to = vm.addr(senderSk); // Use the sender's address as recipient
+
+        uint256 notSenderSk = senderSk == user1Sk ? user2Sk : user1Sk;
+        address from = vm.addr(senderSk);
+
+        // Make permit signature from notFromSk, but call from 'from'
+        (uint8 v, bytes32 r, bytes32 s) = getPermitSignature(
+            notSenderSk, 
+            from,
+            address(payments), 
+            amount, 
+            deadline
+        );
+
+        // Capture pre-deposit balances and state
+        uint256 fromBalanceBefore = _balanceOf(from, false);
+        uint256 paymentsBalanceBefore = _balanceOf(address(payments), false);
+        Payments.Account memory toAccountBefore = _getAccountData(to, false);
+
+        vm.startPrank(from);
+
+        // Expect custom error: ERC2612InvalidSigner(wrongRecovered, expectedOwner)
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "ERC2612InvalidSigner(address,address)",
+                vm.addr(notSenderSk),
+                from
+            )
+        );
+        payments.depositWithPermitAndOperatorApproval(
+            address(testToken), 
+            from, 
+            amount, 
+            deadline, 
+            v, r, s,
+            operator,
+            approved,
+            rateAllowance,
+            lockupAllowance,
+            maxLockupPeriod
+        );
+        vm.stopPrank();
+
+        // Capture post-deposit balances and state
+        uint256 fromBalanceAfter = _balanceOf(from, false);
+        uint256 paymentsBalanceAfter = _balanceOf(address(payments), false);
+        Payments.Account memory toAccountAfter = _getAccountData(to, false);
+
+        // Asserts / Checks
+        _assertDepositBalances(
+            fromBalanceBefore,  
+            fromBalanceAfter,
+            paymentsBalanceBefore,
+            paymentsBalanceAfter,
+            toAccountBefore,
+            toAccountAfter,
+            0
+        );
     }
 }


### PR DESCRIPTION
## Summary 

Add `depositWithPermitAndApproveOperator` to support deposit with permit and operator approval in a single transaction.

## Changes

- Features
  - Added `depositWithPermitAndApproveOperator` function to combine EIP-2612 permit, deposit, and operator approval.
  - Refactored: Abstracted core logic of `setOperatorApproval` and `depositWithPermit` into internal functions (`_setOperatorApproval` and `_depositWithPermit`).

- Tests
  - Added tests for new function: successful deposit + approval, zero value, multiple deposits, and invalid signature failure.
  - Refactored test helpers, extracted shared assertion logic.

- Docs
  - Updated `README` to document `depositWithPermit`, `depositWithPermitAndApproveOperator`.
  - Modified `setOperatorApproval` doc in `README` to include `maxLockupPeriod`.

All existing and new test cases are passing.
Closes #133.