### PR TITLE
fix: don't unlock client funds for the full requested settlement duration if arbitrer reduces settled duration

### DIFF
--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1097,8 +1097,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
 
         // Calculate the default settlement values (without validation)
         uint256 duration = epochEnd - epochStart;
-        uint256 expectedSettledAmount = rate * duration;
-        uint256 settledAmount = expectedSettledAmount;
+        uint256 settledAmount = rate * duration;
         uint256 settledUntilEpoch = epochEnd;
         note = "";
 


### PR DESCRIPTION
https://github.com/FilOzone/filecoin-services-payments/pull/141 fixed the bug where client funds do not get unlocked if arbitrer settles the full duration but not the full amount i.e. reduced the requested settlement amount.

This PR fixes the other bug where arbitrer can reduce the settled duration as well. In this case, we should only unlock client funds for the duration settled by the arbitrer and not for the entire requested settlement duration.