### PR TITLE
fix: reliable deploys with env loading and script permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,22 @@
 # Makefile for Payment Contracts
 
+# Helper: Ensure relevant scripts are executable
+.PHONY: chmod-deploy
+chmod-deploy:
+	chmod +x ./tools/deploy.sh
+
+.PHONY : chmod-upgrade
+chmod-upgrade:
+	chmod +x ./tools/upgrade-contract.sh
+
+.PHONY: chmod-transfer
+chmod-transfer:
+	chmod +x ./tools/transfer-owner.sh
+
+.PHONY: chmod-get-owner
+chmod-get-owner:
+	chmod +x ./tools/get-owner.sh
+
 # Default target
 .PHONY: default
 default: build test
@@ -25,36 +42,36 @@ test:
 
 # Deployment targets
 .PHONY: deploy-calibnet
-deploy-calibnet:
+deploy-calibnet: chmod-deploy
 	./tools/deploy.sh 314159
 
 .PHONY: deploy-devnet
-deploy-devnet:
+deploy-devnet: chmod-deploy
 	./tools/deploy.sh 31415926
 
 .PHONY: deploy-mainnet
-deploy-mainnet:
+deploy-mainnet: chmod-deploy
 	./tools/deploy.sh 314
 
 # Upgrade targets
 .PHONY: upgrade-calibnet
-upgrade-calibnet:
+upgrade-calibnet: chmod-upgrade
 	./tools/upgrade-contract.sh 314159
 
 .PHONY: upgrade-devnet
-upgrade-devnet:
+upgrade-devnet: chmod-upgrade
 	./tools/upgrade-contract.sh 31415926
 
 .PHONY: upgrade-mainnet
-upgrade-mainnet:
+upgrade-mainnet: chmod-upgrade
 	./tools/upgrade-contract.sh 314
 
 # Ownership management targets
 .PHONY: transfer-owner
-transfer-owner:
+transfer-owner: chmod-transfer
 	./tools/transfer-owner.sh
 
 .PHONY: get-owner
-get-owner:
+get-owner: chmod-get-owner
 	./tools/get-owner.sh
 

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -5,6 +5,9 @@
 #          ./tools/deploy.sh 314 (mainnet)
 #          ./tools/deploy.sh 31415926 (devnet)
 #
+if [ -f ".env" ]; then
+  export $(grep -v '^#' .env | xargs)
+fi
 set -euo pipefail
 
 CHAIN_ID=${1:-314159} # Default to calibnet


### PR DESCRIPTION
## Summary
Improves reliability and developer experience for contract deployment by ensuring scripts have correct permissions and environment variables are consistently loaded.

## Problem


- Issue: permission denied
![Screenshot: Makefile target fails with Permission denied (Error 127)](https://github.com/user-attachments/assets/4c38fadc-4f60-43d2-8316-b24b7cb45db9)

- Issue: environment variable not set even after sourcing .env
![Screenshot: "KEYSTORE is not set" error after sourcing .env and running make deploy-calibnet](https://github.com/user-attachments/assets/5663c7d5-8573-45e7-b9d1-8ec3b13354bc)


## Changes
- Adds `.env` loading logic to `deploy.sh` for consistent environment variable access
- Updates Makefile with explicit `chmod` targets to ensure deploy, upgrade, and admin scripts are executable before running
- Prevents common errors after a fresh clone due to missing env vars or script permissions