### PR TITLE
Add migration guide for Foundry v1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@ out/
 /broadcast/*/31337/
 /broadcast/**/dry-run/
 
-# Docs
-docs/
-
 # Dotenv file
 .env
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 The FWS Payments contract enables ERC20 token payment flows through "rails" - automated payment channels between clients and recipients. The contract supports continuous payments, one-time transfers, and payment validation/arbitration.
 
 - [Deployment Info](#deployment-info)
+- [Migration to Foundry v1.0 and Later](docs/migration-to-foundry-v1.md) *(read this if upgrading from pre-v1.0 Foundry or contract exceeds the EIP-170 size limit)*
 - [Key Concepts](#key-concepts)
 - [Core Functions](#core-functions)
   - [Account Management](#account-management)

--- a/docs/migration-to-foundry-v1.md
+++ b/docs/migration-to-foundry-v1.md
@@ -20,6 +20,10 @@ Error: server returned an error response: error code 11: message execution faile
 02: f01009 (method 1) -- EVM byte code length (40517) is exceeding the maximum allowed of 24576 (16)
 ```
 
+## Root Cause
+
+The contract size increases in Foundry `v1.0` and later because the Solidity optimizer is disabled by default, whereas it was previously enabled. This results in much larger bytecode unless you explicitly enable the optimizer in your configuration.
+
 ## Solution
 
 To restore the previous behavior and ensure your contracts remain deployable, **explicitly enable the optimizer** in your `foundry.toml` configuration file:

--- a/docs/migration-to-foundry-v1.md
+++ b/docs/migration-to-foundry-v1.md
@@ -1,0 +1,36 @@
+# Migration to Foundry v1.0+ and Later
+
+## Background
+
+If you are upgrading your project from an older version of Foundry (such as `0.3.x`) to Foundry `v1.0` or later (including `1.2.x`), you need to be aware of an important change in the default compiler settings that affects contract deployment.
+
+## Change in Default Optimizer Behavior (Breaking change)
+
+Starting with Foundry `v1.0`, the Solidity optimizer is disabled by default. In previous versions, the optimizer was enabled by default (with approximately 200 runs). This change can cause the compiled contract bytecode to be significantly larger if you do not explicitly enable the optimizer in your configuration.
+
+Reference: [Foundry v1.0 Migration Guide](https://getfoundry.sh/misc/v1.0-migration/#solc-optimizer-disabled-by-default)
+
+## Impact
+
+If you compile contracts with Foundry `v1.0+` using the default settings, you may encounter deployment errors on networks that enforce the [`EIP-170`](https://eips.ethereum.org/EIPS/eip-170) contract size limit (24,576 bytes, or 24 KB). For example, deploying to Filecoin EVM, Ethereum mainnet, or other compatible chains may fail with errors such as:
+```bash
+Error: server returned an error response: error code 11: message execution failed (exit=[ErrIllegalArgument(16)], revert reason=[message failed with backtrace:
+00: f010 (method 4) -- send aborted with code 16 (16)
+01: f01 (method 3) -- constructor failed: send aborted with code 16 (16)
+02: f01009 (method 1) -- EVM byte code length (40517) is exceeding the maximum allowed of 24576 (16)
+```
+
+## Solution
+
+To restore the previous behavior and ensure your contracts remain deployable, **explicitly enable the optimizer** in your `foundry.toml` configuration file:
+
+```toml
+optimizer = true
+optimizer_runs = 200
+```
+
+You can adjust `optimizer_runs` for different trade-offs between contract size and gas efficiency:
+- `200`: Minimize bytecode size
+-  `10000` or `20000` (or even higher): Produces slightly larger contracts but reduces gas cost per function call.
+
+Higher values may slightly increase contract size but can reduce gas costs on repeated usage. Ensure the contract size stays below the EIP-170 limit.


### PR DESCRIPTION
## Summary

- Adds a migration guide (`docs/migration-to-foundry-v1.md`) for upgrading this project to Foundry v1.0 or later.
- The guide documents the cause and solution for contract size errors encountered during development.
- Updates the README to link to the migration guide for easy reference by anyone who encounters this issue.

## Changes

- Adds file `docs/migration-to-foundry-v1.md`
- Added migration guide link to README

Closes #168 