### PR TITLE
Zero segment bug

### DIFF
--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1122,7 +1122,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
                 rail.settledUpTo = segmentEndBoundary;
                 state.processedEpoch = segmentEndBoundary;
 
-                // Remove the processed rate change from the queue if it exists AND we have processed it entirely 
+                // Remove the processed rate change from the queue if it exists AND we have processed it entirely
                 if (!rateQueue.isEmpty() && (segmentEndBoundary >= rateQueue.peek().untilEpoch)) {
                     rateQueue.dequeue();
                 }

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1123,7 +1123,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
                 state.processedEpoch = segmentEndBoundary;
 
                 // Remove the processed rate change from the queue if it exists AND we have processed it entirely
-                if (!rateQueue.isEmpty() && (segmentEndBoundary >= rateQueue.peek().untilEpoch)) {
+                if (!rateQueue.isEmpty() && segmentEndBoundary >= rateQueue.peek().untilEpoch) {
                     rateQueue.dequeue();
                 }
 
@@ -1161,7 +1161,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
             state.note = validationNote;
 
             // Remove the processed rate change from the queue
-            if (!rateQueue.isEmpty()) {
+            if (!rateQueue.isEmpty() && segmentEndBoundary >= rateQueue.peek().untilEpoch) {
                 rateQueue.dequeue();
             }
         }

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1122,8 +1122,8 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
                 rail.settledUpTo = segmentEndBoundary;
                 state.processedEpoch = segmentEndBoundary;
 
-                // Remove the processed rate change from the queue if it exists
-                if (!rateQueue.isEmpty()) {
+                // Remove the processed rate change from the queue if it exists AND we have processed it entirely 
+                if (!rateQueue.isEmpty() && (segmentEndBoundary >= rateQueue.peek().untilEpoch)) {
                     rateQueue.dequeue();
                 }
 

--- a/test/RailSettlement.t.sol
+++ b/test/RailSettlement.t.sol
@@ -812,8 +812,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
     }
 
     function testPartialSettleOfZeroSegment() public {
-        uint256 rateOn = 1 ;
-        uint256 rateOff = 0 ;
+        uint256 rateOn = 1;
+        uint256 rateOff = 0;
 
         helper.setupOperatorApproval(USER1, OPERATOR, 1000 ether, 100000 ether, MAX_LOCKUP_PERIOD);
 

--- a/test/RailSettlement.t.sol
+++ b/test/RailSettlement.t.sol
@@ -812,17 +812,10 @@ contract RailSettlementTest is Test, BaseTestHelper {
     }
 
     function testPartialSettleOfZeroSegment() public {
-
         uint256 rateOn = 1 ether;
         uint256 rateOff = 0 ether;
 
-        helper.setupOperatorApproval(
-            USER1,
-            OPERATOR,
-            1000 ether,
-            100000 ether,
-            MAX_LOCKUP_PERIOD
-        );
+        helper.setupOperatorApproval(USER1, OPERATOR, 1000 ether, 100000 ether, MAX_LOCKUP_PERIOD);
 
         uint256 railId = helper.setupRailWithParameters(
             USER1,
@@ -835,35 +828,34 @@ contract RailSettlementTest is Test, BaseTestHelper {
             SERVICE_FEE_RECIPIENT // operator commision receiver
         );
 
-
         /* 
         |  rate == 1 | rate == 0 | rate == 1 |
         | 100 blocks | 100 blocks | 100 blocks |
                           X^                  Y^
                     First settle          Second settle
         */
-        // Advance 100 blocks and turn rate off 
+        // Advance 100 blocks and turn rate off
         // This adds a rate == 1, untilEpoch == 100 segment to the queue
         helper.advanceBlocks(100);
         vm.prank(OPERATOR);
         payments.modifyRailPayment(railId, rateOff, 0);
         vm.stopPrank();
 
-        // Advance 100 blocks and turn rate on 
+        // Advance 100 blocks and turn rate on
         // This adds a rate == 0, untilEpoch == 200 segment to the queue
         helper.advanceBlocks(100);
         vm.prank(OPERATOR);
         payments.modifyRailPayment(railId, rateOn, 0);
         vm.stopPrank();
 
-        // Advance 100 blocks and turn rate off 
+        // Advance 100 blocks and turn rate off
         // This adds a final rate == 1, untilEpoch == 300 segment to the queue
         helper.advanceBlocks(100);
         vm.prank(OPERATOR);
         payments.modifyRailPayment(railId, rateOff, 0);
         vm.stopPrank();
 
-        // Settle partway through the second segment 
+        // Settle partway through the second segment
         settlementHelper.settleRailAndVerify(railId, 150, 100 ether, 150);
 
         // Settle the whole rail, we should see another 100 tokens transferred

--- a/test/RailSettlement.t.sol
+++ b/test/RailSettlement.t.sol
@@ -811,6 +811,65 @@ contract RailSettlementTest is Test, BaseTestHelper {
         console.log("Zero -> Non-zero -> Zero settlement note:", result.note);
     }
 
+    function testPartialSettleOfZeroSegment() public {
+
+        uint256 rateOn = 1 ether;
+        uint256 rateOff = 0 ether;
+
+        helper.setupOperatorApproval(
+            USER1,
+            OPERATOR,
+            1000 ether,
+            100000 ether,
+            MAX_LOCKUP_PERIOD
+        );
+
+        uint256 railId = helper.setupRailWithParameters(
+            USER1,
+            USER2,
+            OPERATOR,
+            rateOn,
+            0, // No lockup period
+            0, // No fixed lockup
+            address(0), // No arbiter
+            SERVICE_FEE_RECIPIENT // operator commision receiver
+        );
+
+
+        /* 
+        |  rate == 1 | rate == 0 | rate == 1 |
+        | 100 blocks | 100 blocks | 100 blocks |
+                          X^                  Y^
+                    First settle          Second settle
+        */
+        // Advance 100 blocks and turn rate off 
+        // This adds a rate == 1, untilEpoch == 100 segment to the queue
+        helper.advanceBlocks(100);
+        vm.prank(OPERATOR);
+        payments.modifyRailPayment(railId, rateOff, 0);
+        vm.stopPrank();
+
+        // Advance 100 blocks and turn rate on 
+        // This adds a rate == 0, untilEpoch == 200 segment to the queue
+        helper.advanceBlocks(100);
+        vm.prank(OPERATOR);
+        payments.modifyRailPayment(railId, rateOn, 0);
+        vm.stopPrank();
+
+        // Advance 100 blocks and turn rate off 
+        // This adds a final rate == 1, untilEpoch == 300 segment to the queue
+        helper.advanceBlocks(100);
+        vm.prank(OPERATOR);
+        payments.modifyRailPayment(railId, rateOff, 0);
+        vm.stopPrank();
+
+        // Settle partway through the second segment 
+        settlementHelper.settleRailAndVerify(railId, 150, 100 ether, 150);
+
+        // Settle the whole rail, we should see another 100 tokens transferred
+        settlementHelper.settleRailAndVerify(railId, 300, 100 ether, 300);
+    }
+
     function testModifyTerminatedRailBeyondEndEpoch() public {
         uint256 networkFee = payments.NETWORK_FEE();
         // Create a rail with standard parameters including fixed lockup

--- a/test/RailSettlement.t.sol
+++ b/test/RailSettlement.t.sol
@@ -812,8 +812,8 @@ contract RailSettlementTest is Test, BaseTestHelper {
     }
 
     function testPartialSettleOfZeroSegment() public {
-        uint256 rateOn = 1 ether;
-        uint256 rateOff = 0 ether;
+        uint256 rateOn = 1 ;
+        uint256 rateOff = 0 ;
 
         helper.setupOperatorApproval(USER1, OPERATOR, 1000 ether, 100000 ether, MAX_LOCKUP_PERIOD);
 
@@ -856,10 +856,10 @@ contract RailSettlementTest is Test, BaseTestHelper {
         vm.stopPrank();
 
         // Settle partway through the second segment
-        settlementHelper.settleRailAndVerify(railId, 150, 100 ether, 150);
+        settlementHelper.settleRailAndVerify(railId, 150, 100, 150);
 
         // Settle the whole rail, we should see another 100 tokens transferred
-        settlementHelper.settleRailAndVerify(railId, 300, 100 ether, 300);
+        settlementHelper.settleRailAndVerify(railId, 301, 100, 301);
     }
 
     function testModifyTerminatedRailBeyondEndEpoch() public {

--- a/test/RailSettlement.t.sol
+++ b/test/RailSettlement.t.sol
@@ -865,10 +865,10 @@ contract RailSettlementTest is Test, BaseTestHelper {
         vm.stopPrank();
 
         // Settle partway through the second segment
-        settlementHelper.settleRailAndVerify(railId, 151, 100 * rateOn + 50*rateOff, 151);
+        settlementHelper.settleRailAndVerify(railId, 151, 100 * rateOn + 50 * rateOff, 151);
 
         // Settle the whole rail, we should see another 100 tokens transferred
-        settlementHelper.settleRailAndVerify(railId, 301, 50*rateOff + 100 * rateOn, 301);
+        settlementHelper.settleRailAndVerify(railId, 301, 50 * rateOff + 100 * rateOn, 301);
     }
 
     function testModifyTerminatedRailBeyondEndEpoch() public {

--- a/test/RailSettlement.t.sol
+++ b/test/RailSettlement.t.sol
@@ -814,7 +814,16 @@ contract RailSettlementTest is Test, BaseTestHelper {
     function testPartialSettleOfZeroSegment() public {
         uint256 rateOn = 1;
         uint256 rateOff = 0;
+        scaffoldPartialSettleOfSegment(rateOn, rateOff);
+    }
 
+    function testPartialSettleOfNonZeroSegment() public {
+        uint256 rateOn = 2;
+        uint256 rateOff = 1;
+        scaffoldPartialSettleOfSegment(rateOn, rateOff);
+    }
+
+    function scaffoldPartialSettleOfSegment(uint256 rateOn, uint256 rateOff) public {
         helper.setupOperatorApproval(USER1, OPERATOR, 1000 ether, 100000 ether, MAX_LOCKUP_PERIOD);
 
         uint256 railId = helper.setupRailWithParameters(
@@ -856,10 +865,10 @@ contract RailSettlementTest is Test, BaseTestHelper {
         vm.stopPrank();
 
         // Settle partway through the second segment
-        settlementHelper.settleRailAndVerify(railId, 150, 100, 150);
+        settlementHelper.settleRailAndVerify(railId, 151, 100 * rateOn + 50*rateOff, 151);
 
         // Settle the whole rail, we should see another 100 tokens transferred
-        settlementHelper.settleRailAndVerify(railId, 301, 100, 301);
+        settlementHelper.settleRailAndVerify(railId, 301, 50*rateOff + 100 * rateOn, 301);
     }
 
     function testModifyTerminatedRailBeyondEndEpoch() public {


### PR DESCRIPTION
The queue is processed in a fun way such that it prematurely pops off queue segments.  As a consequence the rail can be tricked into paying for the remainder of a partially completed segment at the next segment's rate.  While at first I thought this was confined only to zero segments it is actually a problem for both the zero and nonzero case.

The fix I've added only removes segments from the queue if they have been completely processed.