### PR TITLE
validate permit recipient while increasing operator approval

### DIFF
--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -613,6 +613,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
         nonReentrant
         validateNonZeroAddress(operator, "operator")
         validateNonZeroAddress(to, "to")
+        validatePermitRecipient(to)
         settleAccountLockupBeforeAndAfter(token, to, false)
     {
         _increaseOperatorApproval(token, operator, rateAllowanceIncrease, lockupAllowanceIncrease);


### PR DESCRIPTION

 #185 got merged before #181 , missed the implementation of `validatePermitRecipient` modifier introduced in #185 in the new permit function introduced in #181 :sweat: 
- adds `validatePermitRecipient` modifier to `depositWithPermitAndIncreaseOperatorApproval` function.