### PR TITLE
gitignore Vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ out/
 
 .DS_Store
 LLM.md
+
+# VIM
+*.swp


### PR DESCRIPTION

Reviewer @aarshkshah1992
#### Context
VIM creates these files when you are editing.
They can be used to recover your session in the event vim gets killed.
They should not appear in `git status` or `git diff`.
#### Changes
* add vim swp files to .gitignore