### PR TITLE
View: Truncate instead of Copy

### DIFF
--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1581,7 +1581,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
             // Skip non-existent rails
             if (rail.from == address(0)) continue;
 
-            // Add rail to our temporary array
+            // Add rail info to results
             results[resultCount] =
                 RailInfo({railId: railId, isTerminated: rail.endEpoch > 0, endEpoch: rail.endEpoch});
             resultCount++;

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1587,6 +1587,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
             resultCount++;
         }
 
+        // Truncate
         assembly ("memory-safe") {
             mstore(results, resultCount)
         }

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1571,7 +1571,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
         uint256[] storage allRailIds = isPayer ? payerRails[token][addr] : payeeRails[token][addr];
         uint256 railsLength = allRailIds.length;
 
-        RailInfo[] memory tempResults = new RailInfo[](railsLength);
+        RailInfo[] memory results = new RailInfo[](railsLength);
         uint256 resultCount = 0;
 
         for (uint256 i = 0; i < railsLength; i++) {
@@ -1582,22 +1582,16 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
             if (rail.from == address(0)) continue;
 
             // Add rail to our temporary array
-            tempResults[resultCount] =
+            results[resultCount] =
                 RailInfo({railId: railId, isTerminated: rail.endEpoch > 0, endEpoch: rail.endEpoch});
             resultCount++;
         }
 
-        // Create correctly sized final result array
-        RailInfo[] memory result = new RailInfo[](resultCount);
-
-        // Only copy if we have results (avoid unnecessary operations)
-        if (resultCount > 0) {
-            for (uint256 i = 0; i < resultCount; i++) {
-                result[i] = tempResults[i];
-            }
+        assembly ("memory-safe") {
+            mstore(results, resultCount)
         }
 
-        return result;
+        return results;
     }
 
     /// @notice Number of pending rate-change entries for a rail

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1582,8 +1582,7 @@ contract Payments is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentra
             if (rail.from == address(0)) continue;
 
             // Add rail info to results
-            results[resultCount] =
-                RailInfo({railId: railId, isTerminated: rail.endEpoch > 0, endEpoch: rail.endEpoch});
+            results[resultCount] = RailInfo({railId: railId, isTerminated: rail.endEpoch > 0, endEpoch: rail.endEpoch});
             resultCount++;
         }
 


### PR DESCRIPTION

Reviewer @aarshkshah1992
Solidity memory arrays cannot increase in size once allocated, but it safe to truncate them.
Because memory gas is quadratic, the cost of this copy grows quickly with the size of the array.
By truncating the array we can avoid the copy step.
#### Changes
* replace array copy with array truncation
### Test plan
* verified that without truncation at least one test fails