### PR TITLE
chore: Add GA workflow for test coverage reports

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mkdir:*)",
+      "Bash(forge coverage:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,9 +20,24 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
+          cache: true
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.foundry/cache
+            ~/.foundry/artifacts
+            out
+            cache
+          key: ${{ runner.os }}-foundry-${{ hashFiles('**/foundry.toml') }}-${{ hashFiles('**/remappings.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-foundry-
 
       - name: Run Forge coverage
-        run: forge coverage --report lcov --ir-minimum
+        run: forge coverage --report lcov --ir-minimum --skip test --skip script
+        env:
+          FOUNDRY_PROFILE: ci
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,34 @@
+name: Test Coverage
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run Forge coverage
+        run: forge coverage --report lcov --ir-minimum
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./lcov.info
+          flags: foundry
+          name: foundry-coverage
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ LLM.md
 
 # VIM
 *.swp
+
+# Coverage files
+lcov.info
+coverage-summary.txt
+coverage/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 85%
+        threshold: 2%
+        base: auto
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+        base: auto
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "test/**/*"
+  - "script/**/*"
+  - "lib/**/*"

--- a/foundry.toml
+++ b/foundry.toml
@@ -13,3 +13,8 @@ remappings = [
     '@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/',
     'forge-std/=lib/forge-std/src/',
 ]
+
+[profile.ci]
+optimizer = true
+optimizer_runs = 200
+via_ir = true


### PR DESCRIPTION
resolves #197 
Based on the existing coverage, the codecov % was set to 85%

The report will look like
  ### Codecov Report
  All modified and coverable lines are covered by tests ✅

  > Project coverage is 87.22%. Comparing base (e4e7dcb) to head (c88d4fc).

  > ✅ All tests successful. No failed tests found.

  | [Files](link) | Coverage Δ | |
  |---|---|---|
  | [src/Payments.sol](link) | `92.48%` | |
  | [src/RateChangeQueue.sol](link) | `86.36%` | |

  📊 **Coverage Summary**
  - **Lines**: 87.22% (+0.00%) ✅
  - **Statements**: 87.31% (+0.00%) ✅
  - **Branches**: 36.23% (+0.00%) ⚠️
  - **Functions**: 90.68% (+0.00%) ✅

  📈 **Coverage Diff**
  ```diff
  @@            Coverage Diff             @@
  ##             main      #196      +/-   ##
  ==========================================
    Coverage   87.22%   87.22%
  ==========================================
    Files           2        2
    Lines         923      923
  ==========================================
    Hits          805      805
    Misses        118      118



