### PR TITLE
CI: Update Foundry

### DIFF
--- a/.github/workflows/contract-size.yml
+++ b/.github/workflows/contract-size.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: v0.3.0
+          version: v1.2.3
       
       - name: Install Dependencies
         run: forge install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: v0.3.0
+          version: v1.2.3
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION

Reviewer @rvagg
`lint` already uses 1.2.3
#### Changes
* update `test` and contract size check foundry to 1.2.3